### PR TITLE
feat: add solar & borehole budget explorers

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "zimestimate",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["next", "dev", "--port", "3000"],
+      "port": 3000,
+      "path": "/quick-projects/borehole"
+    }
+  ]
+}

--- a/src/components/quick-projects/BoreholeBudgetExplorer.tsx
+++ b/src/components/quick-projects/BoreholeBudgetExplorer.tsx
@@ -1,0 +1,692 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import {
+  Drop,
+  Lightning,
+  ShieldCheck,
+  Truck,
+  CaretDown,
+  CaretUp,
+  CheckCircle,
+  Warning,
+  Info,
+  FloppyDisk,
+  ArrowLeft,
+  Funnel,
+  Gauge,
+} from '@phosphor-icons/react';
+import { BOREHOLE_PRICES as P, LOCATION_DEFAULTS } from '@/lib/quick-projects/borehole/catalog';
+import { calculateBoreholeBOQ } from '@/lib/quick-projects/borehole/calculations';
+import type { BOQItem, LaborConfig, Answers } from '@/lib/quick-projects/engine/types';
+import QuickBOQTable from './QuickBOQTable';
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+interface ComponentCard {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  enabled: boolean;
+  cost: number;
+  description: string;
+}
+
+type PumpType = 'solar' | 'hybrid' | 'electric' | 'hand';
+type CasingGrade = 'class_6' | 'class_9' | 'class_10';
+type TankSize = '2000' | '2500' | '5000' | '10000' | 'none';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function getSolarKitPrice(depth: number): { price: number; desc: string } {
+  if (depth > 120) return { price: P.solar_kit_3hp, desc: '3.0 HP solar kit (deep/commercial)' };
+  if (depth > 100) return { price: P.solar_kit_2hp, desc: '2.0 HP solar kit' };
+  if (depth > 80)  return { price: P.solar_kit_15hp, desc: '1.5 HP solar kit (high yield)' };
+  if (depth > 50)  return { price: P.solar_kit_1hp, desc: '1.0 HP solar kit' };
+  if (depth > 30)  return { price: P.solar_kit_075hp, desc: '0.75 HP solar kit' };
+  return { price: P.solar_kit_05hp, desc: '0.5 HP solar kit' };
+}
+
+function getHybridKitPrice(depth: number): { price: number; desc: string } {
+  if (depth > 100) return { price: P.hybrid_kit_2hp, desc: '2.0 HP hybrid AC/DC kit' };
+  if (depth > 60)  return { price: P.hybrid_kit_15hp, desc: '1.5 HP hybrid AC/DC kit' };
+  return { price: P.hybrid_kit_1hp, desc: '1.0 HP hybrid AC/DC kit' };
+}
+
+function getElectricKitPrice(depth: number): { price: number; desc: string } {
+  if (depth > 120) return { price: P.electric_kit_3hp, desc: '3.0 HP electric submersible' };
+  if (depth > 100) return { price: P.electric_kit_2hp, desc: '2.0 HP electric submersible' };
+  if (depth > 50)  return { price: P.electric_kit_1hp, desc: '1.0 HP electric submersible' };
+  return { price: P.electric_kit_075hp, desc: '0.75 HP electric submersible' };
+}
+
+function getPumpPrice(type: PumpType, depth: number): { price: number; desc: string } {
+  switch (type) {
+    case 'solar': return getSolarKitPrice(depth);
+    case 'hybrid': return getHybridKitPrice(depth);
+    case 'electric': return getElectricKitPrice(depth);
+    case 'hand': return { price: P.pump_hand_afridev, desc: 'Afridev hand pump' };
+  }
+}
+
+function getCasingPrice(grade: CasingGrade, diameter: '140mm' | '180mm'): number {
+  const d = diameter === '180mm' ? '180' : '140';
+  const c = grade === 'class_10' ? 'c10' : grade === 'class_9' ? 'c9' : 'c6';
+  const key = `casing_upvc_${d}_${c}` as keyof typeof P;
+  return (P[key] as number) ?? P.casing_upvc_140_c6;
+}
+
+function getCasingLabel(grade: CasingGrade): string {
+  if (grade === 'class_10') return 'Class 10 — premium';
+  if (grade === 'class_9') return 'Class 9 — mid-grade';
+  return 'Class 6 — standard';
+}
+
+function getTankCost(size: TankSize, useCombo: boolean): { cost: number; desc: string } {
+  if (size === 'none') return { cost: 0, desc: 'No tank' };
+  if (useCombo && size === '10000') return { cost: P.combo_10000L_4m, desc: '10,000L tank + 4m stand (combo)' };
+  if (useCombo && size === '5000') return { cost: P.combo_5000L_4m, desc: '5,000L tank + 4m stand (combo)' };
+  const tankKey = `tank_${size}L` as keyof typeof P;
+  const tankPrice = (P[tankKey] as number) ?? 700;
+  return { cost: tankPrice + P.tank_stand_4m, desc: `${Number(size).toLocaleString()}L tank + 4m stand (separate)` };
+}
+
+// ─── Props ─────────────────────────────────────────────────────────────────────
+
+interface BoreholeBudgetExplorerProps {
+  onBack: () => void;
+  isContractor?: boolean;
+  onSave?: (items: BOQItem[], answers: Answers, labor: LaborConfig) => void;
+}
+
+// ─── Component ─────────────────────────────────────────────────────────────────
+
+export default function BoreholeBudgetExplorer({ onBack, isContractor = false, onSave }: BoreholeBudgetExplorerProps) {
+  // Budget
+  const [budget, setBudget] = useState<number>(5000);
+
+  // Depth slider
+  const [depth, setDepth] = useState<number>(40);
+
+  // Purpose
+  const [purpose, setPurpose] = useState<'domestic' | 'commercial'>('domestic');
+
+  // Location
+  const [location, setLocation] = useState<string>('other');
+
+  // Enabled cards
+  const [enabledCards, setEnabledCards] = useState<Record<string, boolean>>({
+    drilling: true,
+    casing: true,
+    pump: true,
+    tank: true,
+    services: true,
+    permits: true,
+    transport: true,
+  });
+
+  // Options
+  const [pumpType, setPumpType] = useState<PumpType>('solar');
+  const [casingGrade, setCasingGrade] = useState<CasingGrade>('class_6');
+  const [tankSize, setTankSize] = useState<TankSize>('5000');
+  const [useCombo, setUseCombo] = useState(true);
+
+  // Expanded card
+  const [expandedCard, setExpandedCard] = useState<string | null>(null);
+
+  // BOQ view
+  const [boqItems, setBoqItems] = useState<BOQItem[] | null>(null);
+  const [labor, setLabor] = useState<LaborConfig>({ enabled: false, method: 'percentage', percentage: 25 });
+
+  // Save dialog
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [projectName, setProjectName] = useState('');
+
+  const locMeta = LOCATION_DEFAULTS[location] || LOCATION_DEFAULTS.other;
+  const areaType = ['harare', 'bulawayo', 'chitungwiza'].includes(location) ? 'urban' : 'peri_urban';
+  const diameter = purpose === 'domestic' ? '140mm' as const : '180mm' as const;
+
+  // ── Costs ─────────────────────────────────────────────────────────────────
+  const costs = useMemo(() => {
+    const drillingCost = enabledCards.drilling ? depth * P.drilling_per_m : 0;
+
+    const casingPerM = getCasingPrice(casingGrade, diameter);
+    const casingCost = enabledCards.casing ? depth * casingPerM : 0;
+    const gravelCost = enabledCards.casing ? +(depth * 0.03).toFixed(1) * P.gravel_pack_per_m3 + P.wellhead_assembly : 0;
+
+    const pump = getPumpPrice(pumpType, depth);
+    const risingMain = pumpType !== 'hand' ? (depth + 5) * (purpose === 'domestic' ? P.rising_hdpe_25mm : P.rising_hdpe_32mm) : 0;
+    const pumpCost = enabledCards.pump ? pump.price + risingMain + P.pump_installation : 0;
+
+    const tank = getTankCost(tankSize, useCombo);
+    const tankCost = enabledCards.tank ? tank.cost : 0;
+
+    const surveyKey = `site_survey_${areaType}` as keyof typeof P;
+    const surveyCost = (P[surveyKey] as number) || P.site_survey_peri_urban;
+    const servicesCost = enabledCards.services
+      ? surveyCost + P.borehole_flushing + P.yield_test + P.water_test_bacteriological
+      : 0;
+
+    const permitsCost = enabledCards.permits ? P.zinwa_permit_gw1 + locMeta.councilFee : 0;
+
+    const extraKm = areaType === 'urban' ? 0 : 15;
+    const mobilCost = P.mobilization_base + Math.max(0, extraKm) * P.mobilization_per_km;
+    const transportCost = enabledCards.transport ? mobilCost : 0;
+
+    return {
+      drilling: drillingCost,
+      casing: casingCost + gravelCost,
+      pump: pumpCost,
+      tank: tankCost,
+      services: servicesCost,
+      permits: permitsCost,
+      transport: transportCost,
+      pumpDesc: pump.desc,
+      tankDesc: tank.desc,
+      casingLabel: getCasingLabel(casingGrade),
+    };
+  }, [enabledCards, depth, pumpType, casingGrade, tankSize, useCombo, purpose, diameter, areaType, locMeta]);
+
+  const totalAllocated = Object.entries(costs)
+    .filter(([k]) => !['pumpDesc', 'tankDesc', 'casingLabel'].includes(k))
+    .reduce((s, [, v]) => s + (typeof v === 'number' ? v : 0), 0);
+  const remaining = budget - totalAllocated;
+  const budgetPct = Math.min(100, Math.round((totalAllocated / budget) * 100));
+
+  const toggleCard = useCallback((id: string) => {
+    setEnabledCards((prev) => ({ ...prev, [id]: !prev[id] }));
+  }, []);
+
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedCard((prev) => (prev === id ? null : id));
+  }, []);
+
+  // Generate BOQ using existing budget calculator
+  const generateBOQ = () => {
+    const answers: Answers = {
+      estimate_mode: 'budget',
+      budget_amount: String(budget),
+      budget_depth: String(depth),
+      borehole_purpose: purpose,
+      project_location: location,
+      area_type: areaType,
+    };
+    const items = calculateBoreholeBOQ(answers);
+    setBoqItems(items);
+  };
+
+  // ── BOQ View ──────────────────────────────────────────────────────────────
+  if (boqItems) {
+    return (
+      <div className="w-full max-w-5xl mx-auto animate-fade-in pb-24">
+        <button
+          onClick={() => setBoqItems(null)}
+          className="flex items-center gap-2 text-sm font-medium text-slate-500 hover:text-blue-600 transition-colors mb-6"
+        >
+          <ArrowLeft size={16} /> Back to Budget Explorer
+        </button>
+        <QuickBOQTable
+          projectType="borehole"
+          initialItems={boqItems}
+          labor={labor}
+          onLaborChange={setLabor}
+          isContractor={isContractor}
+          onSave={onSave ? (items) => onSave(items, { estimate_mode: 'budget', budget_amount: String(budget), budget_depth: String(depth), borehole_purpose: purpose, project_location: location, area_type: areaType }, labor) : undefined}
+        />
+      </div>
+    );
+  }
+
+  // ── Card definitions ──────────────────────────────────────────────────────
+  const cards: ComponentCard[] = [
+    {
+      id: 'drilling',
+      label: 'Drilling',
+      icon: <Gauge size={22} weight="duotone" />,
+      enabled: enabledCards.drilling,
+      cost: costs.drilling,
+      description: `${depth}m depth × $${P.drilling_per_m}/m — standard rotary drilling`,
+    },
+    {
+      id: 'casing',
+      label: 'Casing & Wellhead',
+      icon: <Funnel size={22} weight="duotone" />,
+      enabled: enabledCards.casing,
+      cost: costs.casing,
+      description: `PVC ${diameter} ${costs.casingLabel} + gravel pack + wellhead`,
+    },
+    {
+      id: 'pump',
+      label: 'Pump & Power',
+      icon: <Lightning size={22} weight="duotone" />,
+      enabled: enabledCards.pump,
+      cost: costs.pump,
+      description: costs.pumpDesc + ' + rising main + installation',
+    },
+    {
+      id: 'tank',
+      label: 'Water Storage',
+      icon: <Drop size={22} weight="duotone" />,
+      enabled: enabledCards.tank,
+      cost: costs.tank,
+      description: costs.tankDesc,
+    },
+    {
+      id: 'services',
+      label: 'Professional Services',
+      icon: <ShieldCheck size={22} weight="duotone" />,
+      enabled: enabledCards.services,
+      cost: costs.services,
+      description: 'Site survey, flushing, yield test, water quality test',
+    },
+    {
+      id: 'permits',
+      label: 'Permits & Compliance',
+      icon: <CheckCircle size={22} weight="duotone" />,
+      enabled: enabledCards.permits,
+      cost: costs.permits,
+      description: `ZINWA GW1 permit ($${P.zinwa_permit_gw1}) + council fee ($${locMeta.councilFee})`,
+    },
+    {
+      id: 'transport',
+      label: 'Mobilization',
+      icon: <Truck size={22} weight="duotone" />,
+      enabled: enabledCards.transport,
+      cost: costs.transport,
+      description: 'Drilling rig transport to site',
+    },
+  ];
+
+  return (
+    <div className="w-full max-w-4xl mx-auto pb-24">
+      {/* Back */}
+      <button onClick={onBack} className="flex items-center gap-2 text-sm font-medium text-slate-500 hover:text-blue-600 transition-colors mb-6">
+        <ArrowLeft size={16} /> Back to Borehole Setup
+      </button>
+
+      {/* Header */}
+      <div className="mb-8">
+        <span className="text-xs font-bold uppercase tracking-[0.2em] text-blue-500 mb-2 block">BOREHOLE BUDGET EXPLORER</span>
+        <h2 className="text-2xl font-bold text-slate-900 mb-2">What can your budget buy?</h2>
+        <p className="text-slate-600 text-base">Enter your budget, adjust depth and options. Toggle components on/off to see what fits.</p>
+      </div>
+
+      {/* ── Budget Input ─────────────────────────────────────────────────────── */}
+      <div className="p-6 rounded-2xl border border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50 mb-6">
+        <label className="block text-sm font-bold text-slate-700 mb-3">Your Budget (USD)</label>
+        <div className="flex items-center gap-4">
+          <span className="text-3xl font-extrabold text-slate-400">$</span>
+          <input
+            type="number"
+            min={1000}
+            step={500}
+            value={budget}
+            onChange={(e) => setBudget(Math.max(1000, Number(e.target.value) || 1000))}
+            className="flex-1 text-4xl font-extrabold text-slate-900 bg-transparent border-none outline-none focus:ring-0 appearance-none [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            style={{ MozAppearance: 'textfield' } as any}
+          />
+        </div>
+        <div className="flex flex-wrap gap-2 mt-4">
+          {[2000, 3000, 5000, 7500, 10000, 15000].map((amt) => (
+            <button
+              key={amt}
+              type="button"
+              onClick={() => setBudget(amt)}
+              className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+                budget === amt ? 'bg-blue-600 text-white' : 'bg-white border border-slate-200 text-slate-600 hover:border-blue-300 hover:text-blue-600'
+              }`}
+            >
+              ${amt.toLocaleString()}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Config Row: Depth + Purpose + Location ───────────────────────────── */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        {/* Depth slider */}
+        <div className="p-4 rounded-xl border border-slate-200 bg-white">
+          <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">Drilling Depth</label>
+          <div className="text-3xl font-extrabold text-slate-900 mb-2">{depth}m</div>
+          <input
+            type="range"
+            min={20}
+            max={160}
+            step={5}
+            value={depth}
+            onChange={(e) => setDepth(Number(e.target.value))}
+            className="w-full accent-blue-600"
+          />
+          <div className="flex justify-between text-xs text-slate-400 mt-1">
+            <span>20m</span>
+            <span>160m</span>
+          </div>
+          {depth < 40 && (
+            <p className="text-xs text-amber-600 mt-2 font-medium">Below 40m may not reach the water table in many areas of Zimbabwe.</p>
+          )}
+        </div>
+
+        {/* Purpose */}
+        <div className="p-4 rounded-xl border border-slate-200 bg-white">
+          <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">Purpose</label>
+          <div className="flex flex-col gap-2">
+            {[
+              { id: 'domestic' as const, label: 'Domestic', desc: 'Home use, 140mm casing' },
+              { id: 'commercial' as const, label: 'Commercial', desc: 'Farm/business, 180mm casing' },
+            ].map((opt) => (
+              <button
+                key={opt.id}
+                onClick={() => setPurpose(opt.id)}
+                className={`text-left p-2.5 rounded-lg border text-sm transition-colors ${
+                  purpose === opt.id ? 'border-blue-500 bg-blue-50 text-blue-800' : 'border-slate-200 text-slate-600 hover:border-blue-300'
+                }`}
+              >
+                <span className="font-semibold">{opt.label}</span>
+                <span className="block text-xs opacity-70">{opt.desc}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Location */}
+        <div className="p-4 rounded-xl border border-slate-200 bg-white">
+          <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">Location</label>
+          <select
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            className="w-full p-2.5 rounded-lg border border-slate-200 text-sm font-medium text-slate-700 bg-white focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20 outline-none"
+          >
+            {Object.entries(LOCATION_DEFAULTS).map(([key, meta]: [string, { depth: number; councilFee: number }]) => (
+              <option key={key} value={key}>
+                {key.charAt(0).toUpperCase() + key.slice(1)} (avg {meta.depth}m)
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-slate-400 mt-2">Average depth: {locMeta.depth}m · Council fee: ${locMeta.councilFee}</p>
+        </div>
+      </div>
+
+      {/* ── Budget Progress Bar ──────────────────────────────────────────────── */}
+      <div className="mb-6">
+        <div className="flex justify-between text-sm mb-2">
+          <span className="font-semibold text-slate-700">${totalAllocated.toLocaleString(undefined, { maximumFractionDigits: 0 })} allocated</span>
+          <span className={`font-semibold ${remaining >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+            {remaining >= 0 ? `$${remaining.toLocaleString(undefined, { maximumFractionDigits: 0 })} remaining` : `$${Math.abs(remaining).toLocaleString(undefined, { maximumFractionDigits: 0 })} over budget`}
+          </span>
+        </div>
+        <div className="h-3 w-full bg-slate-100 rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all duration-500 ease-out ${
+              budgetPct > 100 ? 'bg-red-500' : budgetPct > 90 ? 'bg-amber-500' : 'bg-gradient-to-r from-blue-500 to-emerald-400'
+            }`}
+            style={{ width: `${Math.min(budgetPct, 100)}%` }}
+          />
+        </div>
+        <div className="flex justify-between text-xs text-slate-400 mt-1">
+          <span>$0</span>
+          <span>${budget.toLocaleString()}</span>
+        </div>
+      </div>
+
+      {/* ── Component Cards ──────────────────────────────────────────────────── */}
+      <div className="space-y-3 mb-8">
+        {cards.map((card) => {
+          const isExpanded = expandedCard === card.id;
+          const hasOptions = ['pump', 'casing', 'tank'].includes(card.id);
+
+          return (
+            <div
+              key={card.id}
+              className={`rounded-2xl border transition-all duration-200 overflow-hidden ${
+                card.enabled ? 'border-blue-200 bg-white shadow-sm' : 'border-slate-200 bg-slate-50/50 opacity-60'
+              }`}
+            >
+              {/* Header */}
+              <div className="flex items-center gap-3 p-4">
+                <button
+                  onClick={() => toggleCard(card.id)}
+                  className={`relative w-11 h-6 rounded-full transition-colors flex-shrink-0 ${card.enabled ? 'bg-blue-600' : 'bg-slate-300'}`}
+                >
+                  <div className={`absolute top-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${card.enabled ? 'translate-x-[22px]' : 'translate-x-0.5'}`} />
+                </button>
+                <div className={`flex-shrink-0 ${card.enabled ? 'text-blue-600' : 'text-slate-400'}`}>{card.icon}</div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between">
+                    <span className={`font-semibold text-sm ${card.enabled ? 'text-slate-900' : 'text-slate-500'}`}>{card.label}</span>
+                    <span className={`text-lg font-bold tabular-nums ${card.enabled ? 'text-slate-900' : 'text-slate-400'}`}>
+                      ${Math.round(card.cost).toLocaleString()}
+                    </span>
+                  </div>
+                  <p className="text-xs text-slate-500 mt-0.5 truncate">{card.description}</p>
+                </div>
+                {hasOptions && card.enabled && (
+                  <button onClick={() => toggleExpand(card.id)} className="p-1.5 rounded-lg hover:bg-slate-100 text-slate-400 hover:text-blue-600 transition-colors flex-shrink-0">
+                    {isExpanded ? <CaretUp size={16} /> : <CaretDown size={16} />}
+                  </button>
+                )}
+              </div>
+
+              {/* Expanded options */}
+              <AnimatePresence>
+                {isExpanded && card.enabled && (
+                  <motion.div
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: 'auto', opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: 0.2 }}
+                    className="overflow-hidden"
+                  >
+                    <div className="px-4 pb-4 pt-1 border-t border-slate-100">
+                      {/* Pump picker */}
+                      {card.id === 'pump' && (
+                        <div className="grid grid-cols-2 gap-2">
+                          {([
+                            { id: 'solar' as PumpType, label: 'Solar', desc: 'Pump + panels + controller + frame', tier: 'recommended' },
+                            { id: 'hybrid' as PumpType, label: 'Hybrid AC/DC', desc: 'Auto-switches between solar & ZESA grid', tier: 'mid' },
+                            { id: 'electric' as PumpType, label: 'Electric', desc: 'Requires ZESA grid or generator power', tier: 'budget' },
+                            { id: 'hand' as PumpType, label: 'Hand Pump', desc: 'Afridev — no electricity needed', tier: 'basic' },
+                          ]).map((opt) => {
+                            const p = getPumpPrice(opt.id, depth);
+                            return (
+                              <button
+                                key={opt.id}
+                                onClick={() => setPumpType(opt.id)}
+                                className={`flex flex-col items-start p-3 rounded-xl border text-left text-sm transition-colors ${
+                                  pumpType === opt.id ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500/20' : 'border-slate-200 bg-white hover:border-blue-300'
+                                }`}
+                              >
+                                <div className="flex w-full items-center justify-between">
+                                  <span className="font-semibold text-slate-800">{opt.label}</span>
+                                  <span className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${
+                                    opt.tier === 'recommended' ? 'bg-green-100 text-green-700' : opt.tier === 'basic' ? 'bg-slate-100 text-slate-600' : 'bg-blue-100 text-blue-700'
+                                  }`}>{opt.tier}</span>
+                                </div>
+                                <span className="text-xs text-slate-500 mt-1">{opt.desc}</span>
+                                <span className="text-xs font-medium text-slate-600 mt-1">${p.price.toLocaleString()} for {depth}m depth</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+
+                      {/* Casing picker */}
+                      {card.id === 'casing' && (
+                        <div className="grid grid-cols-3 gap-2">
+                          {([
+                            { id: 'class_6' as CasingGrade, label: 'Class 6', desc: 'Standard residential' },
+                            { id: 'class_9' as CasingGrade, label: 'Class 9', desc: 'Mid-grade durability' },
+                            { id: 'class_10' as CasingGrade, label: 'Class 10', desc: 'Premium / deep wells' },
+                          ]).map((opt) => {
+                            const price = getCasingPrice(opt.id, diameter);
+                            return (
+                              <button
+                                key={opt.id}
+                                onClick={() => setCasingGrade(opt.id)}
+                                className={`flex flex-col items-start p-3 rounded-xl border text-left text-sm transition-colors ${
+                                  casingGrade === opt.id ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500/20' : 'border-slate-200 bg-white hover:border-blue-300'
+                                }`}
+                              >
+                                <span className="font-semibold text-slate-800">{opt.label}</span>
+                                <span className="text-xs text-slate-500">{opt.desc}</span>
+                                <span className="text-xs font-medium text-slate-600 mt-1">${price.toFixed(2)}/m × {depth}m = ${Math.round(price * depth)}</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+
+                      {/* Tank picker */}
+                      {card.id === 'tank' && (
+                        <div className="space-y-3">
+                          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                            {([
+                              { id: '2000' as TankSize, label: '2,000L' },
+                              { id: '2500' as TankSize, label: '2,500L' },
+                              { id: '5000' as TankSize, label: '5,000L' },
+                              { id: '10000' as TankSize, label: '10,000L' },
+                            ]).map((opt) => {
+                              const t = getTankCost(opt.id, useCombo);
+                              return (
+                                <button
+                                  key={opt.id}
+                                  onClick={() => setTankSize(opt.id)}
+                                  className={`flex flex-col items-center p-3 rounded-xl border text-sm transition-colors ${
+                                    tankSize === opt.id ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500/20' : 'border-slate-200 bg-white hover:border-blue-300'
+                                  }`}
+                                >
+                                  <span className="font-semibold text-slate-800">{opt.label}</span>
+                                  <span className="text-xs font-medium text-slate-600">${t.cost.toLocaleString()}</span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                          {(tankSize === '5000' || tankSize === '10000') && (
+                            <label className="flex items-center gap-2 p-3 rounded-lg bg-emerald-50 border border-emerald-100 cursor-pointer">
+                              <input
+                                type="checkbox"
+                                checked={useCombo}
+                                onChange={(e) => setUseCombo(e.target.checked)}
+                                className="w-4 h-4 rounded border-slate-300 text-blue-600 focus:ring-blue-600"
+                              />
+                              <span className="text-sm text-emerald-800 font-medium">Use combo package (tank + stand bundled — saves ~$200)</span>
+                            </label>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── System Summary ───────────────────────────────────────────────────── */}
+      <div className="p-5 rounded-2xl border border-slate-200 bg-white shadow-sm mb-6">
+        <h4 className="font-bold text-slate-900 mb-4 flex items-center gap-2">
+          <CheckCircle size={20} weight="fill" className="text-blue-600" />
+          Your Borehole Summary
+        </h4>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+          {[
+            { label: 'Depth', value: `${depth}m`, show: enabledCards.drilling },
+            { label: 'Casing', value: `${diameter} ${getCasingLabel(casingGrade).split(' — ')[0]}`, show: enabledCards.casing },
+            { label: 'Pump', value: pumpType.charAt(0).toUpperCase() + pumpType.slice(1), show: enabledCards.pump },
+            { label: 'Tank', value: tankSize === 'none' ? 'None' : `${Number(tankSize).toLocaleString()}L`, show: enabledCards.tank },
+            { label: 'Location', value: location.charAt(0).toUpperCase() + location.slice(1), show: true },
+            { label: 'Purpose', value: purpose.charAt(0).toUpperCase() + purpose.slice(1), show: true },
+          ]
+            .filter((r) => r.show)
+            .map((row) => (
+              <div key={row.label} className="flex justify-between p-2.5 rounded-lg bg-slate-50">
+                <span className="text-slate-500">{row.label}</span>
+                <strong className="text-slate-900">{row.value}</strong>
+              </div>
+            ))}
+        </div>
+
+        {/* Assumptions */}
+        <div className="mt-4 p-3 rounded-lg bg-blue-50/50 border border-blue-100/50">
+          <p className="text-xs font-semibold text-blue-800 mb-1">Assumptions</p>
+          <ul className="text-xs text-blue-700 space-y-0.5">
+            <li>Prices: Zimbabwe Q1 2026 mid-range market rates</li>
+            <li>Drilling: Standard rotary at ${P.drilling_per_m}/m</li>
+            <li>Solar kits: Includes pump + panels + controller + mounting frame</li>
+            <li>Rising main: HDPE {purpose === 'domestic' ? '25mm' : '32mm'} pipe to surface</li>
+            {!enabledCards.permits && <li className="text-amber-700 font-semibold">Permits disabled — ZINWA permit is legally required</li>}
+          </ul>
+        </div>
+      </div>
+
+      {/* ── Warnings ─────────────────────────────────────────────────────────── */}
+      {depth < 40 && (
+        <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-50 border border-amber-200 mb-6">
+          <Warning size={18} className="flex-shrink-0 mt-0.5 text-amber-600" />
+          <div className="text-sm text-amber-800">
+            <strong>Depth below 40m.</strong> Most Zimbabwe locations require at least 40m to reliably hit the water table. Shallower boreholes risk dry holes or low yield.
+          </div>
+        </div>
+      )}
+
+      {!enabledCards.permits && (
+        <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-50 border border-amber-200 mb-6">
+          <Warning size={18} className="flex-shrink-0 mt-0.5 text-amber-600" />
+          <div className="text-sm text-amber-800">
+            <strong>ZINWA permit is legally required.</strong> Drilling without a permit can result in a $2,000 penalty. Budget at least ${P.zinwa_permit_gw1 + locMeta.councilFee} for permits.
+          </div>
+        </div>
+      )}
+
+      {budget < 2000 && (
+        <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-50 border border-amber-200 mb-6">
+          <Warning size={18} className="flex-shrink-0 mt-0.5 text-amber-600" />
+          <div className="text-sm text-amber-800">
+            <strong>Budget below $2,000.</strong> A basic borehole (drilling + casing + hand pump) typically starts around $2,000-$2,500 in Zimbabwe.
+          </div>
+        </div>
+      )}
+
+      {/* ZESA tip for electric pumps */}
+      {pumpType === 'electric' && enabledCards.pump && (
+        <div className="flex items-start gap-3 p-4 rounded-xl bg-blue-50 border border-blue-100/50 mb-6">
+          <Info size={18} className="flex-shrink-0 mt-0.5 text-blue-600" />
+          <div className="text-sm text-blue-800">
+            <strong>Electric pump selected.</strong> Ensure you have reliable ZESA power or a generator. Consider hybrid if power is intermittent — it auto-switches between solar and grid.
+          </div>
+        </div>
+      )}
+
+      {/* ── Action Buttons ───────────────────────────────────────────────────── */}
+      <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 pt-6 border-t border-slate-200">
+        <Button variant="primary" onClick={generateBOQ} className="shadow-lg shadow-blue-500/25 flex-1" disabled={totalAllocated === 0}>
+          Generate Detailed BOQ
+        </Button>
+        {onSave && (
+          <Button variant="secondary" onClick={() => setShowSaveDialog(true)} icon={<FloppyDisk size={18} />} className="bg-white">
+            Save as Project
+          </Button>
+        )}
+      </div>
+
+      {/* ── Save Dialog ──────────────────────────────────────────────────────── */}
+      <AnimatePresence>
+        {showSaveDialog && (
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => setShowSaveDialog(false)}>
+            <motion.div initial={{ scale: 0.95, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.95, opacity: 0 }} onClick={(e) => e.stopPropagation()} className="w-full max-w-md bg-white rounded-2xl p-6 shadow-xl">
+              <h3 className="text-lg font-bold text-slate-900 mb-4">Save Project</h3>
+              <Input label="Project name" placeholder="e.g. My Borehole Project" value={projectName} onChange={(e) => setProjectName(e.target.value)} />
+              <div className="flex gap-3 mt-6">
+                <Button variant="secondary" onClick={() => setShowSaveDialog(false)} className="flex-1 bg-white">Cancel</Button>
+                <Button variant="primary" onClick={() => { generateBOQ(); setShowSaveDialog(false); }} disabled={!projectName.trim()} className="flex-1">Save</Button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/quick-projects/QuickProjectWizard.tsx
+++ b/src/components/quick-projects/QuickProjectWizard.tsx
@@ -6,6 +6,7 @@ import {
   ArrowRight,
   CheckCircle,
   Info,
+  WarningCircle,
 } from '@phosphor-icons/react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Link from 'next/link';
@@ -13,6 +14,7 @@ import Button from '@/components/ui/Button';
 import { getActiveSteps, getVisibleQuestions, isStepComplete, updateAnswer } from '@/lib/quick-projects/engine/boqEngine';
 import type { Answers, BOQItem, LaborConfig, QuestionFlow, QuestionOption, WizardStep } from '@/lib/quick-projects/engine/types';
 import QuickBOQTable from './QuickBOQTable';
+import BoreholeBudgetExplorer from './BoreholeBudgetExplorer';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -29,11 +31,13 @@ function OptionGrid({
   value,
   multi,
   onChange,
+  hasError,
 }: {
   options: QuestionOption[];
   value: string | string[];
   multi: boolean;
   onChange: (v: string | string[]) => void;
+  hasError?: boolean;
 }) {
   const selected = Array.isArray(value) ? value : value ? [value] : [];
 
@@ -47,7 +51,7 @@ function OptionGrid({
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
+    <div className={`grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4 ${hasError ? 'rounded-xl ring-2 ring-red-300 ring-offset-2' : ''}`}>
       {options.map((opt) => {
         const active = selected.includes(opt.value);
         return (
@@ -84,20 +88,27 @@ function QuestionField({
   notSureIds,
   onChange,
   onNotSure,
+  showValidation,
 }: {
   question: ReturnType<typeof getVisibleQuestions>[number];
   answers: Answers;
   notSureIds: Set<string>;
   onChange: (id: string, value: unknown) => void;
   onNotSure: (id: string, on: boolean) => void;
+  showValidation: boolean;
 }) {
   const val = answers[question.id];
   const isNS = notSureIds.has(question.id);
-
   const tip = question.recommendation?.(answers);
 
+  // Determine if this field has a validation error
+  const isEmpty =
+    val === undefined || val === null || val === '' ||
+    (Array.isArray(val) && val.length === 0);
+  const hasError = showValidation && question.required !== false && isEmpty;
+
   return (
-    <div className="mb-8 p-6 rounded-2xl bg-white border border-slate-200/60 shadow-sm">
+    <div className={`mb-8 p-6 rounded-2xl bg-white border shadow-sm transition-colors ${hasError ? 'border-red-300 bg-red-50/30' : 'border-slate-200/60'}`}>
       <label className="block text-base font-bold text-slate-900 mb-1">{question.title}</label>
       {question.description && <p className="text-sm text-slate-500 mb-4">{question.description}</p>}
 
@@ -117,13 +128,28 @@ function QuestionField({
         </label>
       )}
 
-      {/* Select */}
-      {question.type === 'select' && !isNS && (
+      {/* Select — Dropdown layout */}
+      {question.type === 'select' && question.layout === 'dropdown' && !isNS && (
+        <select
+          value={(val as string) ?? ''}
+          onChange={(e) => onChange(question.id, e.target.value)}
+          className={`w-full mt-4 rounded-xl border px-4 py-3 text-base outline-none transition bg-white appearance-none cursor-pointer focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 ${hasError ? 'border-red-400' : 'border-slate-300'}`}
+        >
+          <option value="" disabled>Select an option...</option>
+          {(question.options ?? []).map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      )}
+
+      {/* Select — Card layout (default) */}
+      {question.type === 'select' && question.layout !== 'dropdown' && !isNS && (
         <OptionGrid
           options={question.options ?? []}
           value={(val as string) ?? ''}
           multi={false}
           onChange={(v) => onChange(question.id, v)}
+          hasError={hasError}
         />
       )}
 
@@ -134,15 +160,42 @@ function QuestionField({
           value={(val as string[]) ?? []}
           multi={true}
           onChange={(v) => onChange(question.id, v)}
+          hasError={hasError}
         />
       )}
 
-      {/* Number */}
-      {question.type === 'number' && !isNS && (
+      {/* Number — Slider layout */}
+      {question.type === 'number' && question.layout === 'slider' && !isNS && (() => {
+        const sliderVal = (val as number) ?? (question.defaultValue as number) ?? question.min ?? 0;
+        return (
+          <div className="mt-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-3xl font-bold text-slate-900">{sliderVal}</span>
+              <span className="text-sm font-medium text-slate-500">{question.unit}</span>
+            </div>
+            <input
+              type="range"
+              min={question.min ?? 0}
+              max={question.max ?? 100}
+              step={question.step ?? 1}
+              value={sliderVal}
+              onChange={(e) => onChange(question.id, parseFloat(e.target.value))}
+              className="w-full h-2 bg-slate-200 rounded-full appearance-none cursor-pointer accent-blue-600 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-blue-600 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:shadow-md"
+            />
+            <div className="flex justify-between text-xs text-slate-400">
+              <span>{question.min ?? 0} {question.unit}</span>
+              <span>{question.max ?? 100} {question.unit}</span>
+            </div>
+          </div>
+        );
+      })()}
+
+      {/* Number — Standard input */}
+      {question.type === 'number' && question.layout !== 'slider' && !isNS && (
         <div className="flex items-center gap-3 mt-4">
           <input
             type="number"
-            className="w-full max-w-[200px] rounded-xl border border-slate-300 px-4 py-3 text-base outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20"
+            className={`w-full max-w-[200px] rounded-xl border px-4 py-3 text-base outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 ${hasError ? 'border-red-400' : 'border-slate-300'}`}
             value={(val as number) ?? (question.defaultValue as number) ?? ''}
             min={question.min}
             max={question.max}
@@ -157,7 +210,7 @@ function QuestionField({
       {question.type === 'text' && (
         <input
           type="text"
-          className="w-full mt-4 rounded-xl border border-slate-300 px-4 py-3 text-base outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20"
+          className={`w-full mt-4 rounded-xl border px-4 py-3 text-base outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 ${hasError ? 'border-red-400' : 'border-slate-300'}`}
           placeholder={question.placeholder ?? ''}
           value={(val as string) ?? ''}
           onChange={(e) => onChange(question.id, e.target.value)}
@@ -173,6 +226,14 @@ function QuestionField({
         >
           {isNS ? '← I know the specifics now, go back to options' : "I'm not sure, use safe estimates"}
         </button>
+      )}
+
+      {/* Validation error */}
+      {hasError && (
+        <div className="mt-3 flex items-center gap-2 text-sm text-red-600">
+          <WarningCircle size={16} weight="fill" />
+          <span>Please select an option to continue.</span>
+        </div>
       )}
 
       {/* Recommendation tip */}
@@ -194,12 +255,14 @@ function StepView({
   notSureIds,
   onChange,
   onNotSure,
+  showValidation,
 }: {
   step: WizardStep;
   answers: Answers;
   notSureIds: Set<string>;
   onChange: (id: string, value: unknown) => void;
   onNotSure: (id: string, on: boolean) => void;
+  showValidation: boolean;
 }) {
   const questions = getVisibleQuestions(step, answers, notSureIds);
   return (
@@ -224,6 +287,7 @@ function StepView({
             notSureIds={notSureIds}
             onChange={onChange}
             onNotSure={onNotSure}
+            showValidation={showValidation}
           />
         ))}
       </div>
@@ -238,6 +302,7 @@ export default function QuickProjectWizard({ flow, onSave, isContractor = false 
   const [notSureIds, setNotSureIds] = useState<Set<string>>(new Set());
   const [stepIndex, setStepIndex] = useState(0);
   const [boqItems, setBoqItems] = useState<BOQItem[] | null>(null);
+  const [showValidation, setShowValidation] = useState(false);
   const [labor, setLabor] = useState<LaborConfig>({
     enabled: false,
     method: 'percentage',
@@ -255,6 +320,8 @@ export default function QuickProjectWizard({ flow, onSave, isContractor = false 
 
   const handleChange = useCallback((id: string, value: unknown) => {
     setAnswers((prev) => updateAnswer(prev, id, value));
+    // Clear validation errors as user interacts
+    setShowValidation(false);
   }, []);
 
   const handleNotSure = useCallback((id: string, on: boolean) => {
@@ -262,7 +329,6 @@ export default function QuickProjectWizard({ flow, onSave, isContractor = false 
       const next = new Set(prev);
       if (on) {
         next.add(id);
-        // Set the question value to 'not_sure' sentinel
         setAnswers((a) => updateAnswer(a, id, 'not_sure'));
       } else {
         next.delete(id);
@@ -270,9 +336,16 @@ export default function QuickProjectWizard({ flow, onSave, isContractor = false 
       }
       return next;
     });
+    setShowValidation(false);
   }, []);
 
   function handleNext() {
+    if (!canProceed) {
+      // Show validation errors instead of blocking the button
+      setShowValidation(true);
+      return;
+    }
+    setShowValidation(false);
     if (isLastStep) {
       const items = flow.calculateBOQ(answers);
       setBoqItems(items);
@@ -282,6 +355,7 @@ export default function QuickProjectWizard({ flow, onSave, isContractor = false 
   }
 
   function handleBack() {
+    setShowValidation(false);
     if (boqItems) {
       setBoqItems(null);
     } else {
@@ -290,6 +364,17 @@ export default function QuickProjectWizard({ flow, onSave, isContractor = false 
   }
 
   const progressPct = boqItems ? 100 : Math.round((stepIndex / totalSteps) * 100);
+
+  // ── Borehole Budget Explorer ────────────────────────────────────────────────
+  if (flow.projectType === 'borehole' && answers.estimate_mode === 'budget' && stepIndex > 0) {
+    return (
+      <BoreholeBudgetExplorer
+        onBack={() => { setStepIndex(0); setAnswers({}); }}
+        isContractor={isContractor}
+        onSave={onSave ? (items, ans, lab) => onSave(items, ans, lab) : undefined}
+      />
+    );
+  }
 
   // ── BOQ Results View ───────────────────────────────────────────────────────
   if (boqItems) {
@@ -333,6 +418,7 @@ export default function QuickProjectWizard({ flow, onSave, isContractor = false 
             notSureIds={notSureIds}
             onChange={handleChange}
             onNotSure={handleNotSure}
+            showValidation={showValidation}
           />
         )}
       </AnimatePresence>
@@ -356,7 +442,6 @@ export default function QuickProjectWizard({ flow, onSave, isContractor = false 
           variant="primary"
           icon={isLastStep ? <CheckCircle size={18} weight="bold" /> : <ArrowRight size={16} />}
           iconPosition="right"
-          disabled={!canProceed}
           onClick={handleNext}
           className={isLastStep ? "bg-emerald-600 hover:bg-emerald-700 text-white" : "shadow-blue-500/25 shadow-lg"}
         >

--- a/src/components/quick-projects/SolarBudgetExplorer.tsx
+++ b/src/components/quick-projects/SolarBudgetExplorer.tsx
@@ -1,0 +1,734 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import {
+  Lightning,
+  BatteryCharging,
+  SolarPanel,
+  ShieldCheck,
+  Truck,
+  Wrench,
+  CaretDown,
+  CaretUp,
+  CheckCircle,
+  Warning,
+  Info,
+  FloppyDisk,
+  ArrowLeft,
+} from '@phosphor-icons/react';
+import {
+  INVERTER_BRANDS,
+  BATTERY_BRANDS,
+  PANEL_BRANDS,
+  SOLAR_PACKAGES,
+  getRequiredZeraTier,
+  type InverterOption,
+  type BatteryOption,
+  type PanelOption,
+} from '@/lib/quick-projects/solar/catalog';
+import { solarSizingToBOQ } from '@/lib/quick-projects/solar/boq';
+import type { BOQItem, LaborConfig } from '@/lib/quick-projects/engine/types';
+import type { SolarWizardOutput } from '@/lib/quick-projects/solar/types';
+import QuickBOQTable from './QuickBOQTable';
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+interface ComponentCard {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  enabled: boolean;
+  cost: number;
+  description: string;
+}
+
+interface BudgetAllocation {
+  panels: { count: number; brand: PanelOption; cost: number };
+  inverter: { kva: number; brand: InverterOption; cost: number };
+  battery: { units: number; brand: BatteryOption; cost: number };
+  protection: { cost: number };
+  installation: { cost: number; pct: number };
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+const INVERTER_SIZES = [3, 5, 8, 10, 12];
+const PROTECTION_FIXED = 35 + 28 + 45 + 55 + 45 + 25 + 25 + 22 + 18 + 35 + 120 + 8; // AVS+breaker+changeover+DB+earth+surgeDC+surgeAC+dcIso+acIso+combiner+mount+antitheft
+
+function bestInverterForBudget(budget: number, brand: InverterOption): { kva: number; price: number } {
+  const sizes = Object.entries(brand.prices)
+    .map(([k, v]) => ({ kva: Number(k), price: v }))
+    .sort((a, b) => b.kva - a.kva);
+  for (const s of sizes) {
+    if (s.price <= budget) return s;
+  }
+  // Return smallest available
+  const smallest = sizes[sizes.length - 1];
+  return smallest ?? { kva: 3, price: 350 };
+}
+
+function allocateBudget(
+  totalBudget: number,
+  panelBrand: PanelOption,
+  inverterBrand: InverterOption,
+  batteryBrand: BatteryOption,
+  enabledCards: Record<string, boolean>,
+): BudgetAllocation {
+  let remaining = totalBudget;
+
+  // 1. Inverter first (core component)
+  const inv = bestInverterForBudget(
+    enabledCards.inverter ? remaining * 0.35 : 0,
+    inverterBrand,
+  );
+  const inverterCost = enabledCards.inverter ? inv.price : 0;
+  remaining -= inverterCost;
+
+  // 2. Battery — allocate ~35% of remaining
+  let batteryUnits = 0;
+  let batteryCost = 0;
+  if (enabledCards.battery && remaining > batteryBrand.unitPrice) {
+    batteryUnits = Math.max(1, Math.floor((remaining * 0.45) / batteryBrand.unitPrice));
+    batteryCost = batteryUnits * batteryBrand.unitPrice;
+    remaining -= batteryCost;
+  }
+
+  // 3. Panels — allocate from remaining
+  let panelCount = 0;
+  let panelCost = 0;
+  if (enabledCards.panels && remaining > panelBrand.pricePerPanel) {
+    panelCount = Math.max(1, Math.floor((remaining * 0.6) / panelBrand.pricePerPanel));
+    panelCost = panelCount * panelBrand.pricePerPanel;
+    remaining -= panelCost;
+  }
+
+  // 4. Protection (fixed cost)
+  const protectionCost = enabledCards.protection ? Math.min(PROTECTION_FIXED, remaining) : 0;
+  remaining -= protectionCost;
+
+  // 5. Installation (20% of hardware)
+  const hardwareTotal = inverterCost + batteryCost + panelCost + protectionCost;
+  const installCost = enabledCards.installation ? Math.min(hardwareTotal * 0.20, remaining) : 0;
+
+  return {
+    panels: { count: panelCount, brand: panelBrand, cost: panelCost },
+    inverter: { kva: inv.kva, brand: inverterBrand, cost: inverterCost },
+    battery: { units: batteryUnits, brand: batteryBrand, cost: batteryCost },
+    protection: { cost: protectionCost },
+    installation: { cost: Math.round(installCost), pct: 20 },
+  };
+}
+
+// ─── Props ─────────────────────────────────────────────────────────────────────
+
+interface SolarBudgetExplorerProps {
+  onBack: () => void;
+  isContractor?: boolean;
+  onSave?: (output: SolarWizardOutput & { boqItems?: BOQItem[] }) => void;
+}
+
+// ─── Component ─────────────────────────────────────────────────────────────────
+
+export default function SolarBudgetExplorer({ onBack, isContractor = false, onSave }: SolarBudgetExplorerProps) {
+  // Budget
+  const [budget, setBudget] = useState<number>(2500);
+
+  // Enabled cards
+  const [enabledCards, setEnabledCards] = useState<Record<string, boolean>>({
+    panels: true,
+    inverter: true,
+    battery: true,
+    protection: true,
+    installation: true,
+  });
+
+  // Brand selections
+  const [panelBrand, setPanelBrand] = useState<string>('ja_solar');
+  const [inverterBrand, setInverterBrand] = useState<string>('must');
+  const [batteryBrand, setBatteryBrand] = useState<string>('dyness');
+
+  // Expanded card for brand picker
+  const [expandedCard, setExpandedCard] = useState<string | null>(null);
+
+  // Project name for saving
+  const [projectName, setProjectName] = useState('');
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+
+  // BOQ view
+  const [boqItems, setBoqItems] = useState<BOQItem[] | null>(null);
+  const [labor, setLabor] = useState<LaborConfig>({ enabled: false, method: 'percentage', percentage: 25 });
+
+  // Resolve brand objects
+  const pBrand = PANEL_BRANDS.find((b) => b.brand === panelBrand) ?? PANEL_BRANDS[1]; // JA Solar
+  const iBrand = INVERTER_BRANDS.find((b) => b.brand === inverterBrand) ?? INVERTER_BRANDS[0]; // Must
+  const bBrand = BATTERY_BRANDS.find((b) => b.brand === batteryBrand) ?? BATTERY_BRANDS[2]; // Dyness
+
+  // Compute allocation
+  const allocation = useMemo(
+    () => allocateBudget(budget, pBrand, iBrand, bBrand, enabledCards),
+    [budget, pBrand, iBrand, bBrand, enabledCards],
+  );
+
+  const totalAllocated = allocation.panels.cost + allocation.inverter.cost + allocation.battery.cost + allocation.protection.cost + allocation.installation.cost;
+  const remaining = budget - totalAllocated;
+  const budgetPct = Math.min(100, Math.round((totalAllocated / budget) * 100));
+
+  // Matching pre-built packages
+  const matchingPackages = useMemo(() => {
+    return SOLAR_PACKAGES
+      .filter((pkg) => pkg.price <= budget * 1.1) // within 10% over budget
+      .sort((a, b) => b.price - a.price)
+      .slice(0, 3);
+  }, [budget]);
+
+  const toggleCard = useCallback((id: string) => {
+    setEnabledCards((prev) => ({ ...prev, [id]: !prev[id] }));
+  }, []);
+
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedCard((prev) => (prev === id ? null : id));
+  }, []);
+
+  // System summary
+  const systemKw = ((allocation.panels.count * pBrand.watt) / 1000).toFixed(1);
+  const storageKwh = (allocation.battery.units * bBrand.unitKwh).toFixed(1);
+  const zeraTier = getRequiredZeraTier(allocation.panels.count * pBrand.watt);
+
+  // Generate BOQ
+  const generateBOQ = () => {
+    const sizingResult = {
+      peakLoadWatts: allocation.inverter.kva * 800,
+      inverterKva: allocation.inverter.kva,
+      batteryKwh: allocation.battery.units * bBrand.unitKwh,
+      solarArrayKw: Number(systemKw),
+      panelCount: allocation.panels.count,
+      dailyEnergyKwh: Number(systemKw) * 5.5 * 0.8,
+      tier: (allocation.inverter.kva <= 3 ? 'small' : allocation.inverter.kva <= 5 ? 'standard' : 'large') as 'small' | 'standard' | 'large',
+      estimatedCostUsd: { low: totalAllocated * 0.9, high: totalAllocated * 1.1 },
+      warnings: [] as string[],
+    };
+
+    const augAnswers = {
+      intent: 'budget' as const,
+      backupHours: null,
+      location: '',
+      propertyType: null,
+      appliances: {},
+      simultaneousLoads: { kettleMicrowave: false, pumpWithHouse: false, geyserWithHouse: false },
+      roof: { type: null, shading: null, orientation: '', spaceM2: null },
+      existing: { hasExisting: false, inverterKva: null, batteryKwh: null, panelCount: null, issues: '' },
+      budgetUsd: budget,
+      quote: { totalUsd: null, inverterKva: null, batteryKwh: null, panelCount: null, panelWatt: null, notes: '' },
+      panel_brand: panelBrand,
+      inverter_brand: inverterBrand,
+      battery_brand: batteryBrand,
+      include_transport: enabledCards.installation,
+      include_install: enabledCards.installation,
+      include_contingency: false,
+    };
+
+    const items = solarSizingToBOQ(sizingResult, augAnswers as any);
+    setBoqItems(items);
+  };
+
+  // ── BOQ View ──────────────────────────────────────────────────────────────────
+  if (boqItems) {
+    return (
+      <div className="w-full max-w-5xl mx-auto animate-fade-in pb-24">
+        <button
+          onClick={() => setBoqItems(null)}
+          className="flex items-center gap-2 text-sm font-medium text-slate-500 hover:text-blue-600 transition-colors mb-6"
+        >
+          <ArrowLeft size={16} /> Back to Budget Explorer
+        </button>
+        <QuickBOQTable
+          projectType="solar"
+          initialItems={boqItems}
+          labor={labor}
+          onLaborChange={setLabor}
+          isContractor={isContractor}
+          onSave={
+            onSave
+              ? (items) =>
+                  onSave({
+                    answers: {
+                      intent: 'budget',
+                      backupHours: null,
+                      location: '',
+                      propertyType: null,
+                      appliances: {} as any,
+                      simultaneousLoads: { kettleMicrowave: false, pumpWithHouse: false, geyserWithHouse: false },
+                      roof: { type: null, shading: null, orientation: '', spaceM2: null },
+                      existing: { hasExisting: false, inverterKva: null, batteryKwh: null, panelCount: null, issues: '' },
+                      budgetUsd: budget,
+                      quote: { totalUsd: null, inverterKva: null, batteryKwh: null, panelCount: null, panelWatt: null, notes: '' },
+                    },
+                    result: null,
+                    boqItems: items,
+                  })
+              : undefined
+          }
+        />
+      </div>
+    );
+  }
+
+  // ── Card definitions ──────────────────────────────────────────────────────────
+  const cards: ComponentCard[] = [
+    {
+      id: 'panels',
+      label: 'Solar Panels',
+      icon: <SolarPanel size={22} weight="duotone" />,
+      enabled: enabledCards.panels,
+      cost: allocation.panels.cost,
+      description: `${allocation.panels.count}x ${pBrand.watt}W ${pBrand.label} — ${systemKw} kW array`,
+    },
+    {
+      id: 'inverter',
+      label: 'Inverter',
+      icon: <Lightning size={22} weight="duotone" />,
+      enabled: enabledCards.inverter,
+      cost: allocation.inverter.cost,
+      description: `${allocation.inverter.kva} kVA ${iBrand.label} hybrid inverter`,
+    },
+    {
+      id: 'battery',
+      label: 'Battery Storage',
+      icon: <BatteryCharging size={22} weight="duotone" />,
+      enabled: enabledCards.battery,
+      cost: allocation.battery.cost,
+      description: `${allocation.battery.units}x ${bBrand.unitKwh}kWh ${bBrand.label} — ${storageKwh} kWh total`,
+    },
+    {
+      id: 'protection',
+      label: 'Protection & BOS',
+      icon: <ShieldCheck size={22} weight="duotone" />,
+      enabled: enabledCards.protection,
+      cost: allocation.protection.cost,
+      description: 'AVS, breakers, changeover switch, DB, earthing, surge protection, mounting',
+    },
+    {
+      id: 'installation',
+      label: 'Installation & Transport',
+      icon: <Truck size={22} weight="duotone" />,
+      enabled: enabledCards.installation,
+      cost: allocation.installation.cost,
+      description: `Labor (${allocation.installation.pct}% of hardware) + equipment delivery`,
+    },
+  ];
+
+  return (
+    <div className="w-full max-w-4xl mx-auto pb-24">
+      {/* Back button */}
+      <button
+        onClick={onBack}
+        className="flex items-center gap-2 text-sm font-medium text-slate-500 hover:text-blue-600 transition-colors mb-6"
+      >
+        <ArrowLeft size={16} /> Back to Solar Setup
+      </button>
+
+      {/* Header */}
+      <div className="mb-8">
+        <span className="text-xs font-bold uppercase tracking-[0.2em] text-blue-500 mb-2 block">
+          SOLAR BUDGET EXPLORER
+        </span>
+        <h2 className="text-2xl font-bold text-slate-900 mb-2">
+          What can your budget buy?
+        </h2>
+        <p className="text-slate-600 text-base">
+          Enter your budget below. Toggle components on/off and change brands to see what fits.
+        </p>
+      </div>
+
+      {/* ── Budget Input ─────────────────────────────────────────────────────── */}
+      <div className="p-6 rounded-2xl border border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50 mb-6">
+        <label className="block text-sm font-bold text-slate-700 mb-3">Your Budget (USD)</label>
+        <div className="flex items-center gap-4">
+          <span className="text-3xl font-extrabold text-slate-400">$</span>
+          <input
+            type="number"
+            min={500}
+            step={100}
+            value={budget}
+            onChange={(e) => setBudget(Math.max(500, Number(e.target.value) || 500))}
+            className="flex-1 text-4xl font-extrabold text-slate-900 bg-transparent border-none outline-none focus:ring-0 appearance-none [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            style={{ MozAppearance: 'textfield' } as any}
+          />
+        </div>
+
+        {/* Quick presets */}
+        <div className="flex flex-wrap gap-2 mt-4">
+          {[1000, 1500, 2500, 3500, 5000, 7500].map((amt) => (
+            <button
+              key={amt}
+              type="button"
+              onClick={() => setBudget(amt)}
+              className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+                budget === amt
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white border border-slate-200 text-slate-600 hover:border-blue-300 hover:text-blue-600'
+              }`}
+            >
+              ${amt.toLocaleString()}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Budget Progress Bar ──────────────────────────────────────────────── */}
+      <div className="mb-6">
+        <div className="flex justify-between text-sm mb-2">
+          <span className="font-semibold text-slate-700">
+            ${totalAllocated.toLocaleString()} allocated
+          </span>
+          <span className={`font-semibold ${remaining >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+            {remaining >= 0 ? `$${remaining.toLocaleString()} remaining` : `$${Math.abs(remaining).toLocaleString()} over budget`}
+          </span>
+        </div>
+        <div className="h-3 w-full bg-slate-100 rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all duration-500 ease-out ${
+              budgetPct > 100 ? 'bg-red-500' : budgetPct > 90 ? 'bg-amber-500' : 'bg-gradient-to-r from-blue-500 to-emerald-400'
+            }`}
+            style={{ width: `${Math.min(budgetPct, 100)}%` }}
+          />
+        </div>
+        <div className="flex justify-between text-xs text-slate-400 mt-1">
+          <span>$0</span>
+          <span>${budget.toLocaleString()}</span>
+        </div>
+      </div>
+
+      {/* ── Component Cards ──────────────────────────────────────────────────── */}
+      <div className="space-y-3 mb-8">
+        {cards.map((card) => {
+          const isExpanded = expandedCard === card.id;
+          const hasBrandPicker = ['panels', 'inverter', 'battery'].includes(card.id);
+
+          return (
+            <div
+              key={card.id}
+              className={`rounded-2xl border transition-all duration-200 overflow-hidden ${
+                card.enabled
+                  ? 'border-blue-200 bg-white shadow-sm'
+                  : 'border-slate-200 bg-slate-50/50 opacity-60'
+              }`}
+            >
+              {/* Card header */}
+              <div className="flex items-center gap-3 p-4">
+                {/* Toggle switch */}
+                <button
+                  onClick={() => toggleCard(card.id)}
+                  className={`relative w-11 h-6 rounded-full transition-colors flex-shrink-0 ${
+                    card.enabled ? 'bg-blue-600' : 'bg-slate-300'
+                  }`}
+                >
+                  <div
+                    className={`absolute top-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${
+                      card.enabled ? 'translate-x-[22px]' : 'translate-x-0.5'
+                    }`}
+                  />
+                </button>
+
+                {/* Icon + label */}
+                <div className={`flex-shrink-0 ${card.enabled ? 'text-blue-600' : 'text-slate-400'}`}>
+                  {card.icon}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between">
+                    <span className={`font-semibold text-sm ${card.enabled ? 'text-slate-900' : 'text-slate-500'}`}>
+                      {card.label}
+                    </span>
+                    <span className={`text-lg font-bold tabular-nums ${card.enabled ? 'text-slate-900' : 'text-slate-400'}`}>
+                      ${card.cost.toLocaleString()}
+                    </span>
+                  </div>
+                  <p className="text-xs text-slate-500 mt-0.5 truncate">{card.description}</p>
+                </div>
+
+                {/* Expand button for brand picker */}
+                {hasBrandPicker && card.enabled && (
+                  <button
+                    onClick={() => toggleExpand(card.id)}
+                    className="p-1.5 rounded-lg hover:bg-slate-100 text-slate-400 hover:text-blue-600 transition-colors flex-shrink-0"
+                  >
+                    {isExpanded ? <CaretUp size={16} /> : <CaretDown size={16} />}
+                  </button>
+                )}
+              </div>
+
+              {/* Expanded brand picker */}
+              <AnimatePresence>
+                {isExpanded && card.enabled && (
+                  <motion.div
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: 'auto', opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: 0.2 }}
+                    className="overflow-hidden"
+                  >
+                    <div className="px-4 pb-4 pt-1 border-t border-slate-100">
+                      {/* Panel brand picker */}
+                      {card.id === 'panels' && (
+                        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                          {PANEL_BRANDS.map((b) => (
+                            <button
+                              key={b.brand}
+                              type="button"
+                              onClick={() => setPanelBrand(b.brand)}
+                              className={`flex flex-col items-start p-3 rounded-xl border text-left text-sm transition-colors ${
+                                panelBrand === b.brand
+                                  ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500/20'
+                                  : 'border-slate-200 bg-white hover:border-blue-300'
+                              }`}
+                            >
+                              <span className="font-semibold text-slate-800">{b.label}</span>
+                              <span className="text-xs text-slate-500">{b.watt}W · ${b.pricePerPanel}/panel</span>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+
+                      {/* Inverter brand picker */}
+                      {card.id === 'inverter' && (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                          {INVERTER_BRANDS.map((b) => {
+                            const price5kva = b.prices[5] ?? Object.values(b.prices)[0];
+                            return (
+                              <button
+                                key={b.brand}
+                                type="button"
+                                onClick={() => setInverterBrand(b.brand)}
+                                className={`flex flex-col items-start p-3 rounded-xl border text-left text-sm transition-colors ${
+                                  inverterBrand === b.brand
+                                    ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500/20'
+                                    : 'border-slate-200 bg-white hover:border-blue-300'
+                                }`}
+                              >
+                                <div className="flex w-full items-center justify-between">
+                                  <span className="font-semibold text-slate-800">{b.label}</span>
+                                  <span
+                                    className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${
+                                      b.tier === 'budget'
+                                        ? 'bg-green-100 text-green-700'
+                                        : b.tier === 'premium'
+                                          ? 'bg-purple-100 text-purple-700'
+                                          : 'bg-blue-100 text-blue-700'
+                                    }`}
+                                  >
+                                    {b.tier}
+                                  </span>
+                                </div>
+                                <span className="text-xs text-slate-500 mt-1">{b.description}</span>
+                                <span className="text-xs font-medium text-slate-600 mt-1">~${price5kva} for 5kVA</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+
+                      {/* Battery brand picker */}
+                      {card.id === 'battery' && (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                          {BATTERY_BRANDS.map((b) => (
+                            <button
+                              key={b.brand}
+                              type="button"
+                              onClick={() => setBatteryBrand(b.brand)}
+                              className={`flex flex-col items-start p-3 rounded-xl border text-left text-sm transition-colors ${
+                                batteryBrand === b.brand
+                                  ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500/20'
+                                  : 'border-slate-200 bg-white hover:border-blue-300'
+                              }`}
+                            >
+                              <div className="flex w-full items-center justify-between">
+                                <span className="font-semibold text-slate-800">{b.label}</span>
+                                <span
+                                  className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${
+                                    b.tier === 'budget'
+                                      ? 'bg-green-100 text-green-700'
+                                      : b.tier === 'premium'
+                                        ? 'bg-purple-100 text-purple-700'
+                                        : 'bg-blue-100 text-blue-700'
+                                  }`}
+                                >
+                                  {b.tier}
+                                </span>
+                              </div>
+                              <span className="text-xs text-slate-500 mt-1">{b.description}</span>
+                              <span className="text-xs font-medium text-slate-600 mt-1">
+                                ${b.unitPrice} per {b.unitKwh}kWh · ${b.pricePerKwh}/kWh
+                              </span>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── System Summary Card ──────────────────────────────────────────────── */}
+      <div className="p-5 rounded-2xl border border-slate-200 bg-white shadow-sm mb-6">
+        <h4 className="font-bold text-slate-900 mb-4 flex items-center gap-2">
+          <CheckCircle size={20} weight="fill" className="text-blue-600" />
+          Your System Summary
+        </h4>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+          {[
+            { label: 'Solar Array', value: `${systemKw} kW`, show: enabledCards.panels },
+            { label: 'Panels', value: `${allocation.panels.count}x ${pBrand.watt}W`, show: enabledCards.panels },
+            { label: 'Inverter', value: `${allocation.inverter.kva} kVA`, show: enabledCards.inverter },
+            { label: 'Battery', value: `${storageKwh} kWh`, show: enabledCards.battery },
+            { label: 'Protection', value: enabledCards.protection ? 'Included' : 'Not included', show: true },
+            { label: 'ZERA Tier', value: zeraTier, show: enabledCards.panels },
+          ]
+            .filter((r) => r.show)
+            .map((row) => (
+              <div key={row.label} className="flex justify-between p-2.5 rounded-lg bg-slate-50">
+                <span className="text-slate-500">{row.label}</span>
+                <strong className="text-slate-900">{row.value}</strong>
+              </div>
+            ))}
+        </div>
+
+        {/* Assumptions */}
+        <div className="mt-4 p-3 rounded-lg bg-blue-50/50 border border-blue-100/50">
+          <p className="text-xs font-semibold text-blue-800 mb-1">Assumptions</p>
+          <ul className="text-xs text-blue-700 space-y-0.5">
+            <li>Prices: Zimbabwe Q1 2026 mid-range market rates</li>
+            <li>Sun hours: 5.5h/day average (Zimbabwe)</li>
+            <li>Installation: 20% of hardware cost</li>
+            <li>Battery: LiFePO4 with 90-95% depth of discharge</li>
+            {!enabledCards.protection && (
+              <li className="text-amber-700 font-semibold">
+                Protection layer disabled — not recommended, #1 cause of system failure
+              </li>
+            )}
+          </ul>
+        </div>
+      </div>
+
+      {/* ── Matching Packages ────────────────────────────────────────────────── */}
+      {matchingPackages.length > 0 && (
+        <div className="p-5 rounded-2xl border border-slate-200 bg-white shadow-sm mb-6">
+          <h4 className="font-bold text-slate-900 mb-3 flex items-center gap-2">
+            <Info size={18} className="text-blue-600" />
+            Pre-Built Packages Near Your Budget
+          </h4>
+          <p className="text-xs text-slate-500 mb-3">Real packages from Zimbabwe suppliers:</p>
+          <div className="space-y-2">
+            {matchingPackages.map((pkg) => (
+              <div key={pkg.id} className="p-3 rounded-xl border border-slate-100 bg-slate-50">
+                <div className="flex items-center justify-between">
+                  <span className="font-semibold text-sm text-slate-800">{pkg.name}</span>
+                  <span className={`font-bold ${pkg.price <= budget ? 'text-emerald-600' : 'text-amber-600'}`}>
+                    ${pkg.price.toLocaleString()}
+                  </span>
+                </div>
+                <p className="text-xs text-slate-500 mt-0.5">
+                  {pkg.provider} · {pkg.kva}kVA · {pkg.batteryKwh}kWh · {pkg.panelCount}x {pkg.panelWatt}W
+                </p>
+                <p className="text-xs text-slate-400 mt-0.5">Runs: {pkg.appliances}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Warning if no protection ─────────────────────────────────────────── */}
+      {!enabledCards.protection && (
+        <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-50 border border-amber-200 mb-6">
+          <Warning size={18} className="flex-shrink-0 mt-0.5 text-amber-600" />
+          <div className="text-sm text-amber-800">
+            <strong>Protection layer disabled.</strong> AVS, surge protection, and proper earthing are the #1 factor preventing premature system failure. Strongly recommended even on tight budgets.
+          </div>
+        </div>
+      )}
+
+      {/* ── Budget too low warning ───────────────────────────────────────────── */}
+      {budget < 900 && (
+        <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-50 border border-amber-200 mb-6">
+          <Warning size={18} className="flex-shrink-0 mt-0.5 text-amber-600" />
+          <div className="text-sm text-amber-800">
+            <strong>Budget below $900.</strong> The minimum entry-level solar system in Zimbabwe starts around $900. Consider increasing your budget or starting with a basic lighting kit.
+          </div>
+        </div>
+      )}
+
+      {/* ── Action Buttons ───────────────────────────────────────────────────── */}
+      <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 pt-6 border-t border-slate-200">
+        <Button
+          variant="primary"
+          onClick={generateBOQ}
+          className="shadow-lg shadow-blue-500/25 flex-1"
+          disabled={totalAllocated === 0}
+        >
+          Generate Detailed BOQ
+        </Button>
+        {onSave && (
+          <Button
+            variant="secondary"
+            onClick={() => setShowSaveDialog(true)}
+            icon={<FloppyDisk size={18} />}
+            className="bg-white"
+          >
+            Save as Project
+          </Button>
+        )}
+      </div>
+
+      {/* ── Save Dialog ──────────────────────────────────────────────────────── */}
+      <AnimatePresence>
+        {showSaveDialog && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+            onClick={() => setShowSaveDialog(false)}
+          >
+            <motion.div
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.95, opacity: 0 }}
+              onClick={(e) => e.stopPropagation()}
+              className="w-full max-w-md bg-white rounded-2xl p-6 shadow-xl"
+            >
+              <h3 className="text-lg font-bold text-slate-900 mb-4">Save Project</h3>
+              <Input
+                label="Project name"
+                placeholder="e.g. My Solar System"
+                value={projectName}
+                onChange={(e) => setProjectName(e.target.value)}
+              />
+              <div className="flex gap-3 mt-6">
+                <Button variant="secondary" onClick={() => setShowSaveDialog(false)} className="flex-1 bg-white">
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  onClick={() => {
+                    generateBOQ();
+                    setShowSaveDialog(false);
+                  }}
+                  disabled={!projectName.trim()}
+                  className="flex-1"
+                >
+                  Save
+                </Button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/quick-projects/SolarQuickWizard.tsx
+++ b/src/components/quick-projects/SolarQuickWizard.tsx
@@ -9,8 +9,10 @@ import {
   CheckCircle,
   Warning,
   HouseSimple,
-  MapPin,
   SunDim,
+  ShieldCheck,
+  Wrench,
+  Info,
 } from '@phosphor-icons/react';
 import {
   buildDefaultSelections,
@@ -21,18 +23,34 @@ import {
   SOLAR_APPLIANCES,
   SOLAR_INTENT_LABELS,
   SOLAR_PANEL_WATT,
+  SOLAR_PACKAGES,
+  INVERTER_BRANDS,
+  BATTERY_BRANDS,
+  PANEL_BRANDS,
+  MAINTENANCE_SERVICES,
+  getRequiredZeraTier,
 } from '@/lib/quick-projects/solar/catalog';
 import type {
   SolarIntent,
   SolarWizardAnswers,
   SolarWizardOutput,
 } from '@/lib/quick-projects/solar/types';
-import { solarSizingToBOQ } from '@/lib/quick-projects/solar/boq';
+import { solarSizingToBOQ, maintenanceToBOQ } from '@/lib/quick-projects/solar/boq';
 import type { BOQItem, LaborConfig } from '@/lib/quick-projects/engine/types';
 import QuickBOQTable from './QuickBOQTable';
-import LaborSection from './LaborSection';
+import SolarBudgetExplorer from './SolarBudgetExplorer';
 
-const INTENTS: SolarIntent[] = ['backup', 'heavy_backup', 'off_grid', 'replace', 'budget', 'quote_check'];
+const INTENTS: SolarIntent[] = ['backup', 'heavy_backup', 'off_grid', 'replace', 'budget', 'quote_check', 'maintenance'];
+
+const INTENT_DESCRIPTIONS: Record<SolarIntent, string> = {
+  backup: 'Keep lights, WiFi, and TV running during ZESA outages.',
+  heavy_backup: 'Run fridge, freezer, and heavy loads during 4-8 hour outages.',
+  off_grid: 'Full independence from ZESA — power everything 24/7.',
+  replace: 'Upgrade or replace existing panels, inverter, or batteries.',
+  budget: 'Tell us your budget and we\'ll find the best system that fits.',
+  quote_check: 'Got a quote? We\'ll verify it against Zimbabwe market prices.',
+  maintenance: 'Panel cleaning, diagnostics, battery replacement, or repairs.',
+};
 
 const defaultAnswers: SolarWizardAnswers = {
   intent: null,
@@ -71,6 +89,7 @@ const defaultAnswers: SolarWizardAnswers = {
 
 const stepOrder = [
   'intent',
+  'maintenance_select',
   'context',
   'backup',
   'appliances',
@@ -88,16 +107,20 @@ type StepId = typeof stepOrder[number];
 
 const stepTitles: Record<StepId, { title: string; subtitle: string }> = {
   intent: {
-    title: 'What do you want from solar?',
-    subtitle: 'This helps us tailor the system to your goals in Zimbabwe.',
+    title: 'What do you need?',
+    subtitle: 'Choose your goal — we\'ll tailor the experience to match.',
+  },
+  maintenance_select: {
+    title: 'What services do you need?',
+    subtitle: 'Select all maintenance and servicing tasks you need done.',
   },
   context: {
     title: 'Property context',
-    subtitle: 'Location and property type help us frame usage patterns.',
+    subtitle: 'Location and property type help us size your system correctly.',
   },
   backup: {
     title: 'Backup hours',
-    subtitle: 'Most households target 4–8 hours due to ZESA outages.',
+    subtitle: 'Most households target 4–8 hours due to ZESA load shedding.',
   },
   appliances: {
     title: 'Appliance audit',
@@ -105,31 +128,31 @@ const stepTitles: Record<StepId, { title: string; subtitle: string }> = {
   },
   simultaneous: {
     title: 'Simultaneous loads',
-    subtitle: 'These raise inverter size because motors have surge power.',
+    subtitle: 'These raise inverter size because motors have surge power (up to 3× running watts).',
   },
   roof: {
     title: 'Roof and installation',
     subtitle: `Each panel needs about 2 m². Panel wattage assumed at ${SOLAR_PANEL_WATT}W.`,
   },
   existing: {
-    title: 'Existing system (optional)',
+    title: 'Existing system',
     subtitle: 'Tell us what you already have so we can size upgrades properly.',
   },
   budget: {
     title: 'Budget fit',
-    subtitle: 'We will propose the best system within your budget.',
+    subtitle: 'Enter your budget and we\'ll find the best system from real Zimbabwe packages.',
   },
   quote: {
     title: 'Quote check',
-    subtitle: 'Let us sanity‑check a supplier quote against market tiers.',
+    subtitle: 'Enter the details from your supplier quote — we\'ll check it against market rates.',
   },
   results: {
-    title: 'Solar recommendation',
-    subtitle: 'Here is your sizing summary and cost estimate.',
+    title: 'Your Solar Recommendation',
+    subtitle: 'Here is your sizing summary, matching packages, and cost estimate.',
   },
   brands: {
-    title: 'Brand preferences',
-    subtitle: 'Select your preferred equipment brands or leave as "No preference".',
+    title: 'Equipment preferences',
+    subtitle: 'Choose your preferred brands or leave as default for the best value.',
   },
   optional_costs: {
     title: 'Optional costs',
@@ -148,14 +171,17 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
   const [currentStep, setCurrentStep] = useState<StepId>('intent');
 
   // Brand preferences
-  const [panelBrand, setPanelBrand] = useState('no_pref');
-  const [inverterBrand, setInverterBrand] = useState('no_pref');
-  const [batteryBrand, setBatteryBrand] = useState('no_pref');
+  const [panelBrand, setPanelBrand] = useState('ja_solar');
+  const [inverterBrand, setInverterBrand] = useState('must');
+  const [batteryBrand, setBatteryBrand] = useState('dyness');
 
   // Optional costs
-  const [includeTransport, setIncludeTransport] = useState(false);
+  const [includeTransport, setIncludeTransport] = useState(true);
   const [includeInstall, setIncludeInstall] = useState(true);
   const [includeContingency, setIncludeContingency] = useState(false);
+
+  // Maintenance selections
+  const [selectedMaintenance, setSelectedMaintenance] = useState<string[]>([]);
 
   // BOQ output
   const [boqItems, setBoqItems] = useState<BOQItem[] | null>(null);
@@ -163,24 +189,19 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
 
   const activeSteps = useMemo(() => {
     return stepOrder.filter((step) => {
+      if (step === 'maintenance_select') return answers.intent === 'maintenance';
       if (step === 'backup') {
         return ['backup', 'heavy_backup', 'off_grid', 'replace', 'budget'].includes(answers.intent || '');
       }
       if (step === 'appliances' || step === 'simultaneous' || step === 'roof') {
-        return answers.intent !== 'quote_check';
+        return answers.intent !== 'quote_check' && answers.intent !== 'maintenance';
       }
-      if (step === 'existing') {
-        return answers.intent === 'replace';
-      }
-      if (step === 'budget') {
-        return answers.intent === 'budget';
-      }
-      if (step === 'quote') {
-        return answers.intent === 'quote_check';
-      }
-      // brands and optional_costs only for non-quote-check
+      if (step === 'existing') return answers.intent === 'replace';
+      if (step === 'budget') return answers.intent === 'budget';
+      if (step === 'quote') return answers.intent === 'quote_check';
+      if (step === 'results') return answers.intent !== 'maintenance';
       if (step === 'brands' || step === 'optional_costs') {
-        return answers.intent !== 'quote_check';
+        return answers.intent !== 'quote_check' && answers.intent !== 'maintenance';
       }
       return true;
     });
@@ -191,14 +212,31 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
   const isLast = stepIndex === activeSteps.length - 1;
 
   const result = useMemo(() => {
-    if (!answers.intent || answers.intent === 'quote_check') return null;
+    if (!answers.intent || answers.intent === 'quote_check' || answers.intent === 'maintenance') return null;
     return computeSolarSizing(answers);
   }, [answers]);
 
   const costEstimate = result ? estimateHardwareCost(result) : null;
 
+  // Find matching packages for budget/results
+  const matchingPackages = useMemo(() => {
+    if (!result) return [];
+    return SOLAR_PACKAGES
+      .filter((pkg) => pkg.kva >= result.inverterKva - 2 && pkg.kva <= result.inverterKva + 3)
+      .sort((a, b) => a.price - b.price)
+      .slice(0, 3);
+  }, [result]);
+
+  const budgetPackages = useMemo(() => {
+    if (answers.intent !== 'budget' || !answers.budgetUsd) return [];
+    return SOLAR_PACKAGES
+      .filter((pkg) => pkg.price <= (answers.budgetUsd || 0))
+      .sort((a, b) => b.price - a.price) // best value first (most expensive within budget)
+      .slice(0, 4);
+  }, [answers.intent, answers.budgetUsd]);
+
   const emitChange = (nextAnswers: SolarWizardAnswers) => {
-    const nextResult = nextAnswers.intent && nextAnswers.intent !== 'quote_check'
+    const nextResult = nextAnswers.intent && nextAnswers.intent !== 'quote_check' && nextAnswers.intent !== 'maintenance'
       ? computeSolarSizing(nextAnswers)
       : null;
     onChange({ answers: nextAnswers, result: nextResult });
@@ -214,7 +252,13 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
 
   const goNext = () => {
     if (isLast) {
-      // Generate BOQ on last step
+      // Maintenance path → generate maintenance BOQ
+      if (answers.intent === 'maintenance') {
+        const items = maintenanceToBOQ(selectedMaintenance);
+        setBoqItems(items);
+        return;
+      }
+      // Normal path → generate sizing BOQ
       if (result) {
         const augAnswers = {
           ...answers,
@@ -243,6 +287,17 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
     const prevStep = activeSteps[stepIndex - 1];
     if (prevStep) setCurrentStep(prevStep);
   };
+
+  // ── Budget Explorer view ─────────────────────────────────────────────────
+  if (answers.intent === 'budget' && currentStep !== 'intent') {
+    return (
+      <SolarBudgetExplorer
+        onBack={() => setCurrentStep('intent')}
+        isContractor={isContractor}
+        onSave={onSave ? (output) => onSave(output) : undefined}
+      />
+    );
+  }
 
   // ── BOQ results view ──────────────────────────────────────────────────────
   if (boqItems) {
@@ -295,10 +350,12 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
           className="w-full"
         >
 
+      {/* ── Intent Selection ──────────────────────────────────────────────── */}
       {currentStep === 'intent' && (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
           {INTENTS.map((intent) => {
             const active = answers.intent === intent;
+            const isMaint = intent === 'maintenance';
             return (
               <button
                 key={intent}
@@ -308,7 +365,10 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
               >
                 <div className="flex w-full items-start justify-between gap-2">
                   <div className="flex items-center gap-2">
-                     <Lightning size={20} className={active ? 'text-blue-600' : 'text-slate-400 group-hover:text-blue-500 transition-colors'} />
+                     {isMaint
+                       ? <Wrench size={20} className={active ? 'text-blue-600' : 'text-slate-400 group-hover:text-blue-500 transition-colors'} />
+                       : <Lightning size={20} className={active ? 'text-blue-600' : 'text-slate-400 group-hover:text-blue-500 transition-colors'} />
+                     }
                      <span className={`text-sm font-semibold ${active ? 'text-blue-900' : 'text-slate-800'}`}>
                        {SOLAR_INTENT_LABELS[intent]}
                      </span>
@@ -319,12 +379,51 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
                     <div className="w-5 h-5 rounded-full border border-slate-300 flex-shrink-0 group-hover:border-blue-300 transition-colors" />
                   )}
                 </div>
+                <p className={`mt-2 text-xs leading-relaxed ${active ? 'text-blue-700' : 'text-slate-500'}`}>
+                  {INTENT_DESCRIPTIONS[intent]}
+                </p>
               </button>
             );
           })}
         </div>
       )}
 
+      {/* ── Maintenance Selection ────────────────────────────────────────── */}
+      {currentStep === 'maintenance_select' && (
+        <div className="grid gap-3">
+          {MAINTENANCE_SERVICES.map((svc) => {
+            const selected = selectedMaintenance.includes(svc.id);
+            return (
+              <label
+                key={svc.id}
+                className={`flex items-start gap-3 p-4 rounded-xl border transition-colors cursor-pointer ${selected ? 'border-blue-500 bg-blue-50/20 shadow-sm' : 'border-slate-200 bg-white hover:border-blue-300'}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={selected}
+                  className="mt-0.5 w-5 h-5 rounded border-slate-300 text-blue-600 focus:ring-blue-600 focus:ring-offset-0"
+                  onChange={() => {
+                    setSelectedMaintenance((prev) =>
+                      prev.includes(svc.id)
+                        ? prev.filter((id) => id !== svc.id)
+                        : [...prev, svc.id]
+                    );
+                  }}
+                />
+                <div className="flex-1">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold text-slate-900">{svc.label}</span>
+                    <span className="text-sm font-bold text-slate-600">${svc.price}</span>
+                  </div>
+                  <p className="text-xs text-slate-500 mt-1">{svc.description}</p>
+                </div>
+              </label>
+            );
+          })}
+        </div>
+      )}
+
+      {/* ── Context ──────────────────────────────────────────────────────── */}
       {currentStep === 'context' && (
         <div className="grid gap-6">
           <Input
@@ -354,6 +453,7 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
         </div>
       )}
 
+      {/* ── Backup Hours ─────────────────────────────────────────────────── */}
       {currentStep === 'backup' && (
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
           {[2, 4, 6, 8, 12, 24].map((hours) => {
@@ -374,10 +474,12 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
         </div>
       )}
 
+      {/* ── Appliances ───────────────────────────────────────────────────── */}
       {currentStep === 'appliances' && (
         <div className="grid gap-3">
           {SOLAR_APPLIANCES.map((appliance) => {
             const selection = answers.appliances[appliance.id];
+            if (!selection) return null;
             return (
               <div key={appliance.id} className={`p-4 rounded-xl border transition-colors ${selection.include ? 'border-blue-500 bg-blue-50/20 shadow-sm' : 'border-slate-200 bg-white hover:border-blue-300'}`}>
                 <label className="flex items-center gap-3 cursor-pointer">
@@ -418,16 +520,7 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
                       onChange={(event) => {
                         const qty = Number(event.target.value);
                         setAnswers((prev) => {
-                          const next = {
-                            ...prev,
-                            appliances: {
-                              ...prev.appliances,
-                              [appliance.id]: {
-                                ...prev.appliances[appliance.id],
-                                qty,
-                              },
-                            },
-                          };
+                          const next = { ...prev, appliances: { ...prev.appliances, [appliance.id]: { ...prev.appliances[appliance.id], qty } } };
                           emitChange(next);
                           return next;
                         });
@@ -441,16 +534,7 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
                       onChange={(event) => {
                         const hours = Number(event.target.value);
                         setAnswers((prev) => {
-                          const next = {
-                            ...prev,
-                            appliances: {
-                              ...prev.appliances,
-                              [appliance.id]: {
-                                ...prev.appliances[appliance.id],
-                                hours,
-                              },
-                            },
-                          };
+                          const next = { ...prev, appliances: { ...prev.appliances, [appliance.id]: { ...prev.appliances[appliance.id], hours } } };
                           emitChange(next);
                           return next;
                         });
@@ -464,336 +548,252 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
         </div>
       )}
 
+      {/* ── Simultaneous Loads ────────────────────────────────────────────── */}
       {currentStep === 'simultaneous' && (
         <div className="grid gap-3 p-6 rounded-2xl bg-white border border-slate-200/60 shadow-sm">
-          <label className="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 cursor-pointer transition-colors">
-            <input
-              type="checkbox"
-              className="w-5 h-5 rounded border-slate-300 text-blue-600 focus:ring-blue-600 focus:ring-offset-0"
-              checked={answers.simultaneousLoads.kettleMicrowave}
-              onChange={(event) => updateAnswers({
-                simultaneousLoads: {
-                  ...answers.simultaneousLoads,
-                  kettleMicrowave: event.target.checked,
-                },
-              })}
-            />
-            <span className="text-slate-700 font-medium">Kettle and microwave run together</span>
-          </label>
-          <label className="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 cursor-pointer transition-colors">
-            <input
-              type="checkbox"
-              className="w-5 h-5 rounded border-slate-300 text-blue-600 focus:ring-blue-600 focus:ring-offset-0"
-              checked={answers.simultaneousLoads.pumpWithHouse}
-              onChange={(event) => updateAnswers({
-                simultaneousLoads: {
-                  ...answers.simultaneousLoads,
-                  pumpWithHouse: event.target.checked,
-                },
-              })}
-            />
-            <span className="text-slate-700 font-medium">Pump runs with household loads</span>
-          </label>
-          <label className="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 cursor-pointer transition-colors">
-            <input
-              type="checkbox"
-              className="w-5 h-5 rounded border-slate-300 text-blue-600 focus:ring-blue-600 focus:ring-offset-0"
-              checked={answers.simultaneousLoads.geyserWithHouse}
-              onChange={(event) => updateAnswers({
-                simultaneousLoads: {
-                  ...answers.simultaneousLoads,
-                  geyserWithHouse: event.target.checked,
-                },
-              })}
-            />
-            <span className="text-slate-700 font-medium">Geyser runs with household loads</span>
-          </label>
+          {[
+            { key: 'kettleMicrowave' as const, label: 'Kettle and microwave run together', warn: 'This draws 3,500W+ — needs at least 5kVA inverter' },
+            { key: 'pumpWithHouse' as const, label: 'Pump runs with household loads', warn: 'Pump startup surge can be 3× running watts' },
+            { key: 'geyserWithHouse' as const, label: 'Geyser runs with household loads', warn: 'Geyser draws 3,000W — may need dedicated circuit or 8kVA+ inverter' },
+          ].map((item) => (
+            <label key={item.key} className="flex items-start gap-3 p-3 rounded-lg hover:bg-slate-50 cursor-pointer transition-colors">
+              <input
+                type="checkbox"
+                className="mt-0.5 w-5 h-5 rounded border-slate-300 text-blue-600 focus:ring-blue-600 focus:ring-offset-0"
+                checked={answers.simultaneousLoads[item.key]}
+                onChange={(event) => updateAnswers({
+                  simultaneousLoads: { ...answers.simultaneousLoads, [item.key]: event.target.checked },
+                })}
+              />
+              <div>
+                <span className="text-slate-700 font-medium">{item.label}</span>
+                {answers.simultaneousLoads[item.key] && (
+                  <p className="text-xs text-amber-600 mt-1">⚡ {item.warn}</p>
+                )}
+              </div>
+            </label>
+          ))}
         </div>
       )}
 
+      {/* ── Roof ─────────────────────────────────────────────────────────── */}
       {currentStep === 'roof' && (
         <div className="grid gap-6">
           <Input
             label="Roof orientation"
             placeholder="e.g. North-facing"
             value={answers.roof.orientation}
-            onChange={(event) => updateAnswers({
-              roof: { ...answers.roof, orientation: event.target.value },
-            })}
+            onChange={(event) => updateAnswers({ roof: { ...answers.roof, orientation: event.target.value } })}
           />
           <Input
-            label="Roof space (m²)"
+            label="Available roof space (m²)"
             type="number"
             min={0}
             value={answers.roof.spaceM2 || ''}
-            onChange={(event) => updateAnswers({
-              roof: { ...answers.roof, spaceM2: Number(event.target.value) },
-            })}
+            onChange={(event) => updateAnswers({ roof: { ...answers.roof, spaceM2: Number(event.target.value) } })}
           />
-          <div className="pill-grid">
-            {[
-              { id: 'tile', label: 'Tile' },
-              { id: 'ibr', label: 'IBR' },
-              { id: 'concrete', label: 'Concrete' },
-              { id: 'other', label: 'Other' },
-            ].map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={`pill ${answers.roof.type === item.id ? 'active' : ''}`}
-                onClick={() => updateAnswers({ roof: { ...answers.roof, type: item.id as any } })}
-              >
-                {item.label}
-              </button>
-            ))}
+          <div>
+            <label className="block text-sm font-bold text-slate-700 mb-2">Roof type</label>
+            <div className="flex flex-wrap gap-2">
+              {[
+                { id: 'tile', label: 'Tile' },
+                { id: 'ibr', label: 'IBR (corrugated)' },
+                { id: 'concrete', label: 'Concrete flat' },
+                { id: 'other', label: 'Other' },
+              ].map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  className={`inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-sm transition-colors ${answers.roof.type === item.id ? 'border-blue-500 bg-blue-50 text-blue-700 font-medium' : 'border-slate-200 bg-white text-slate-600 hover:border-blue-300'}`}
+                  onClick={() => updateAnswers({ roof: { ...answers.roof, type: item.id as any } })}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
           </div>
-          <div className="pill-grid">
-            {[
-              { id: 'none', label: 'No shading' },
-              { id: 'partial', label: 'Partial shading' },
-              { id: 'heavy', label: 'Heavy shading' },
-            ].map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={`pill ${answers.roof.shading === item.id ? 'active' : ''}`}
-                onClick={() => updateAnswers({ roof: { ...answers.roof, shading: item.id as any } })}
-              >
-                {item.label}
-              </button>
-            ))}
+          <div>
+            <label className="block text-sm font-bold text-slate-700 mb-2">Shading</label>
+            <div className="flex flex-wrap gap-2">
+              {[
+                { id: 'none', label: 'No shading' },
+                { id: 'partial', label: 'Partial shading' },
+                { id: 'heavy', label: 'Heavy shading' },
+              ].map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  className={`inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-sm transition-colors ${answers.roof.shading === item.id ? 'border-blue-500 bg-blue-50 text-blue-700 font-medium' : 'border-slate-200 bg-white text-slate-600 hover:border-blue-300'}`}
+                  onClick={() => updateAnswers({ roof: { ...answers.roof, shading: item.id as any } })}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
       )}
 
+      {/* ── Existing System ──────────────────────────────────────────────── */}
       {currentStep === 'existing' && (
-        <div className="form-grid">
-          <label className="checkline">
+        <div className="grid gap-4">
+          <label className="flex items-center gap-3 p-4 rounded-xl border border-slate-200 bg-white cursor-pointer hover:bg-slate-50 transition-colors">
             <input
               type="checkbox"
+              className="w-5 h-5 rounded border-slate-300 text-blue-600 focus:ring-blue-600"
               checked={answers.existing.hasExisting}
-              onChange={(event) => updateAnswers({
-                existing: { ...answers.existing, hasExisting: event.target.checked },
-              })}
+              onChange={(event) => updateAnswers({ existing: { ...answers.existing, hasExisting: event.target.checked } })}
             />
-            I already have a solar system
+            <span className="font-medium text-slate-800">I already have a solar system</span>
           </label>
           {answers.existing.hasExisting && (
-            <>
-              <Input
-                label="Current inverter (kVA)"
-                type="number"
-                min={0}
-                value={answers.existing.inverterKva || ''}
-                onChange={(event) => updateAnswers({
-                  existing: { ...answers.existing, inverterKva: Number(event.target.value) },
-                })}
-              />
-              <Input
-                label="Current battery (kWh)"
-                type="number"
-                min={0}
-                value={answers.existing.batteryKwh || ''}
-                onChange={(event) => updateAnswers({
-                  existing: { ...answers.existing, batteryKwh: Number(event.target.value) },
-                })}
-              />
-              <Input
-                label="Current panel count"
-                type="number"
-                min={0}
-                value={answers.existing.panelCount || ''}
-                onChange={(event) => updateAnswers({
-                  existing: { ...answers.existing, panelCount: Number(event.target.value) },
-                })}
-              />
-              <Input
-                label="Main issues (optional)"
-                placeholder="e.g. Battery not lasting, inverter trips"
-                value={answers.existing.issues}
-                onChange={(event) => updateAnswers({
-                  existing: { ...answers.existing, issues: event.target.value },
-                })}
-              />
-            </>
+            <div className="grid gap-4 p-4 rounded-xl border border-slate-200 bg-white">
+              <Input label="Current inverter (kVA)" type="number" min={0} value={answers.existing.inverterKva || ''} onChange={(e) => updateAnswers({ existing: { ...answers.existing, inverterKva: Number(e.target.value) } })} />
+              <Input label="Current battery (kWh)" type="number" min={0} value={answers.existing.batteryKwh || ''} onChange={(e) => updateAnswers({ existing: { ...answers.existing, batteryKwh: Number(e.target.value) } })} />
+              <Input label="Current panel count" type="number" min={0} value={answers.existing.panelCount || ''} onChange={(e) => updateAnswers({ existing: { ...answers.existing, panelCount: Number(e.target.value) } })} />
+              <Input label="Main issues (optional)" placeholder="e.g. Battery not lasting, inverter trips, ZESA temper mode" value={answers.existing.issues} onChange={(e) => updateAnswers({ existing: { ...answers.existing, issues: e.target.value } })} />
+            </div>
           )}
         </div>
       )}
 
+      {/* ── Budget ───────────────────────────────────────────────────────── */}
       {currentStep === 'budget' && (
-        <div className="form-grid">
+        <div className="grid gap-6">
           <Input
             label="Target budget (USD)"
             type="number"
-            min={0}
+            min={500}
+            step={100}
             value={answers.budgetUsd || ''}
             onChange={(event) => updateAnswers({ budgetUsd: Number(event.target.value) })}
           />
-          <div className="info-card">
-            <MapPin size={18} />
-            <p>
-              We will size the system to fit your budget and show trade‑offs (backup hours or heavy loads).
-            </p>
-          </div>
+          {budgetPackages.length > 0 && (
+            <div className="space-y-3">
+              <h4 className="text-sm font-bold text-slate-700">Packages within your budget:</h4>
+              {budgetPackages.map((pkg) => (
+                <div key={pkg.id} className="p-4 rounded-xl border border-slate-200 bg-white">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="font-semibold text-slate-900">{pkg.name}</span>
+                    <span className="text-lg font-bold text-emerald-600">${pkg.price.toLocaleString()}</span>
+                  </div>
+                  <p className="text-xs text-slate-500">{pkg.provider} · {pkg.kva}kVA · {pkg.batteryKwh}kWh · {pkg.panelCount}× {pkg.panelWatt}W panels</p>
+                  <p className="text-xs text-slate-400 mt-1">Runs: {pkg.appliances}</p>
+                </div>
+              ))}
+            </div>
+          )}
+          {answers.budgetUsd && budgetPackages.length === 0 && (
+            <div className="flex items-start gap-3 p-3 rounded-lg bg-amber-50 text-amber-800 border border-amber-100">
+              <Warning size={18} className="flex-shrink-0 mt-0.5" />
+              <span className="text-sm">No standard packages found within ${answers.budgetUsd}. The minimum entry-level system starts around $900. We&apos;ll still size a custom system for your budget.</span>
+            </div>
+          )}
         </div>
       )}
 
+      {/* ── Quote Check ──────────────────────────────────────────────────── */}
       {currentStep === 'quote' && (
-        <div className="form-grid">
-          <Input
-            label="Quoted total price (USD)"
-            type="number"
-            min={0}
-            value={answers.quote.totalUsd || ''}
-            onChange={(event) => updateAnswers({
-              quote: { ...answers.quote, totalUsd: Number(event.target.value) },
-            })}
-          />
-          <Input
-            label="Inverter size (kVA)"
-            type="number"
-            min={0}
-            value={answers.quote.inverterKva || ''}
-            onChange={(event) => updateAnswers({
-              quote: { ...answers.quote, inverterKva: Number(event.target.value) },
-            })}
-          />
-          <Input
-            label="Battery size (kWh)"
-            type="number"
-            min={0}
-            value={answers.quote.batteryKwh || ''}
-            onChange={(event) => updateAnswers({
-              quote: { ...answers.quote, batteryKwh: Number(event.target.value) },
-            })}
-          />
-          <Input
-            label="Panel count"
-            type="number"
-            min={0}
-            value={answers.quote.panelCount || ''}
-            onChange={(event) => updateAnswers({
-              quote: { ...answers.quote, panelCount: Number(event.target.value) },
-            })}
-          />
-          <Input
-            label="Panel wattage"
-            type="number"
-            min={0}
-            value={answers.quote.panelWatt || ''}
-            onChange={(event) => updateAnswers({
-              quote: { ...answers.quote, panelWatt: Number(event.target.value) },
-            })}
-          />
-          <Input
-            label="Notes about the quote"
-            placeholder="e.g. Deye inverter, Dyness battery, 2 year warranty"
-            value={answers.quote.notes}
-            onChange={(event) => updateAnswers({
-              quote: { ...answers.quote, notes: event.target.value },
-            })}
-          />
+        <div className="grid gap-4">
+          <Input label="Quoted total price (USD)" type="number" min={0} value={answers.quote.totalUsd || ''} onChange={(e) => updateAnswers({ quote: { ...answers.quote, totalUsd: Number(e.target.value) } })} />
+          <Input label="Inverter size (kVA)" type="number" min={0} value={answers.quote.inverterKva || ''} onChange={(e) => updateAnswers({ quote: { ...answers.quote, inverterKva: Number(e.target.value) } })} />
+          <Input label="Battery size (kWh)" type="number" min={0} value={answers.quote.batteryKwh || ''} onChange={(e) => updateAnswers({ quote: { ...answers.quote, batteryKwh: Number(e.target.value) } })} />
+          <Input label="Panel count" type="number" min={0} value={answers.quote.panelCount || ''} onChange={(e) => updateAnswers({ quote: { ...answers.quote, panelCount: Number(e.target.value) } })} />
+          <Input label="Panel wattage" type="number" min={0} value={answers.quote.panelWatt || ''} onChange={(e) => updateAnswers({ quote: { ...answers.quote, panelWatt: Number(e.target.value) } })} />
+          <Input label="Notes about the quote" placeholder="e.g. Deye inverter, Dyness battery, 2 year warranty" value={answers.quote.notes} onChange={(e) => updateAnswers({ quote: { ...answers.quote, notes: e.target.value } })} />
         </div>
       )}
 
+      {/* ── Results (sizing) ─────────────────────────────────────────────── */}
       {currentStep === 'results' && result && (
-        <div className="results-grid">
-          <div className="results-card">
-            <h4>Recommended System</h4>
-            <div className="results-row">
-              <span>Inverter size</span>
-              <strong>{result.inverterKva} kVA</strong>
+        <div className="space-y-4">
+          {/* System sizing card */}
+          <div className="p-5 rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <h4 className="font-bold text-slate-900 mb-4 flex items-center gap-2"><ShieldCheck size={20} className="text-blue-600" /> Recommended System</h4>
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              {[
+                { label: 'Inverter', value: `${result.inverterKva} kVA` },
+                { label: 'Battery storage', value: `${result.batteryKwh} kWh` },
+                { label: 'Solar array', value: `${result.solarArrayKw} kW` },
+                { label: 'Panels needed', value: `${result.panelCount} panels` },
+                { label: 'Daily energy', value: `${result.dailyEnergyKwh} kWh` },
+                { label: 'ZERA tier required', value: getRequiredZeraTier(result.solarArrayKw * 1000) },
+              ].map((row) => (
+                <div key={row.label} className="flex justify-between p-2 rounded-lg bg-slate-50">
+                  <span className="text-slate-500">{row.label}</span>
+                  <strong className="text-slate-900">{row.value}</strong>
+                </div>
+              ))}
             </div>
-            <div className="results-row">
-              <span>Battery storage</span>
-              <strong>{result.batteryKwh} kWh</strong>
-            </div>
-            <div className="results-row">
-              <span>Solar array</span>
-              <strong>{result.solarArrayKw} kW</strong>
-            </div>
-            <div className="results-row">
-              <span>Panels needed</span>
-              <strong>{result.panelCount} panels</strong>
-            </div>
-            <div className="results-row">
-              <span>Daily energy</span>
-              <strong>{result.dailyEnergyKwh} kWh</strong>
-            </div>
-            <div className="tier-pill">Tier: {result.tier}</div>
           </div>
 
-          <div className="results-card">
-            <h4>Estimated Cost (USD)</h4>
-            {costEstimate && (
-              <>
-                <div className="results-row">
-                  <span>Hardware</span>
-                  <strong>${costEstimate.hardware}</strong>
-                </div>
-                <div className="results-row">
-                  <span>Installation</span>
-                  <strong>${costEstimate.install}</strong>
-                </div>
-                <div className="results-row">
-                  <span>Total</span>
-                  <strong>${costEstimate.total}</strong>
-                </div>
-              </>
-            )}
-            <div className="hint">Typical range: ${result.estimatedCostUsd.low}–${result.estimatedCostUsd.high}</div>
-          </div>
+          {/* Cost estimate card */}
+          {costEstimate && (
+            <div className="p-5 rounded-2xl border border-slate-200 bg-white shadow-sm">
+              <h4 className="font-bold text-slate-900 mb-4">Estimated Cost (USD)</h4>
+              <div className="grid gap-2 text-sm">
+                <div className="flex justify-between"><span className="text-slate-500">Hardware</span><strong>${costEstimate.hardware.toLocaleString()}</strong></div>
+                <div className="flex justify-between"><span className="text-slate-500">Installation (20%)</span><strong>${costEstimate.install.toLocaleString()}</strong></div>
+                <div className="flex justify-between border-t border-slate-100 pt-2"><span className="font-semibold text-slate-700">Total</span><strong className="text-lg text-emerald-600">${costEstimate.total.toLocaleString()}</strong></div>
+              </div>
+              <p className="text-xs text-slate-400 mt-3">Typical range: ${result.estimatedCostUsd.low.toLocaleString()}–${result.estimatedCostUsd.high.toLocaleString()}</p>
+            </div>
+          )}
 
+          {/* Matching packages */}
+          {matchingPackages.length > 0 && (
+            <div className="p-5 rounded-2xl border border-slate-200 bg-white shadow-sm">
+              <h4 className="font-bold text-slate-900 mb-3">Matching Pre-Built Packages</h4>
+              <p className="text-xs text-slate-500 mb-3">Real packages from Zimbabwe suppliers that match your sizing:</p>
+              {matchingPackages.map((pkg) => (
+                <div key={pkg.id} className="p-3 rounded-xl border border-slate-100 bg-slate-50 mb-2 last:mb-0">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold text-sm text-slate-800">{pkg.name}</span>
+                    <span className="font-bold text-emerald-600">${pkg.price.toLocaleString()}</span>
+                  </div>
+                  <p className="text-xs text-slate-500 mt-0.5">{pkg.provider} · {pkg.kva}kVA · {pkg.batteryKwh}kWh · {pkg.panelCount}× {pkg.panelWatt}W</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Warnings */}
           {result.warnings.length > 0 && (
-            <div className="results-card warning">
-              <h4>
-                <Warning size={18} /> Notes
-              </h4>
-              <ul>
+            <div className="p-5 rounded-2xl border border-amber-200 bg-amber-50/50">
+              <h4 className="font-bold text-amber-900 mb-3 flex items-center gap-2"><Warning size={18} /> Important Notes</h4>
+              <ul className="space-y-2">
                 {result.warnings.map((note) => (
-                  <li key={note}>{note}</li>
+                  <li key={note} className="text-sm text-amber-800 flex items-start gap-2">
+                    <span className="mt-1 block w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0" />
+                    {note}
+                  </li>
                 ))}
               </ul>
             </div>
           )}
 
-          <div className="results-card summary">
-            <h4>Summary</h4>
-            <p>
-              This sizing is tailored for Zimbabwe load‑shedding and assumes hybrid backup usage.
-            </p>
-            <div className="summary-pill">
-              <CheckCircle size={16} /> Ready to save this quick project
+          {/* ZESA integration tip */}
+          <div className="flex items-start gap-3 p-4 rounded-xl bg-blue-50 border border-blue-100/50">
+            <Info size={18} className="flex-shrink-0 mt-0.5 text-blue-600" />
+            <div className="text-sm text-blue-800">
+              <strong>ZESA Integration:</strong> Your installer must separate the solar neutral from the ZESA neutral wire during installation. Incorrect wiring causes prepaid meters to enter &quot;temper mode&quot; and refuse to load tokens.
             </div>
           </div>
         </div>
       )}
 
+      {/* ── Results (quote check) ────────────────────────────────────────── */}
       {currentStep === 'results' && answers.intent === 'quote_check' && (
-        <div className="results-grid">
-          <div className="results-card warning">
-            <h4>
-              <Warning size={18} /> Quote check summary
-            </h4>
-            <p>
-              We will compare your quote against Zimbabwe system tiers once you save this quick project.
-            </p>
-            <div className="results-row">
-              <span>Quoted total</span>
-              <strong>{answers.quote.totalUsd ? `$${answers.quote.totalUsd}` : 'Not provided'}</strong>
+        <div className="space-y-4">
+          <div className="p-5 rounded-2xl border border-amber-200 bg-amber-50/50">
+            <h4 className="font-bold text-amber-900 mb-3 flex items-center gap-2"><Warning size={18} /> Quote Check Summary</h4>
+            <div className="grid gap-2 text-sm">
+              <div className="flex justify-between"><span className="text-slate-600">Quoted total</span><strong>{answers.quote.totalUsd ? `$${answers.quote.totalUsd.toLocaleString()}` : 'Not provided'}</strong></div>
+              <div className="flex justify-between"><span className="text-slate-600">Inverter</span><strong>{answers.quote.inverterKva ? `${answers.quote.inverterKva} kVA` : 'Not provided'}</strong></div>
+              <div className="flex justify-between"><span className="text-slate-600">Battery</span><strong>{answers.quote.batteryKwh ? `${answers.quote.batteryKwh} kWh` : 'Not provided'}</strong></div>
+              <div className="flex justify-between"><span className="text-slate-600">Panels</span><strong>{answers.quote.panelCount ? `${answers.quote.panelCount} panels` : 'Not provided'}</strong></div>
             </div>
-            <div className="results-row">
-              <span>Inverter</span>
-              <strong>{answers.quote.inverterKva ? `${answers.quote.inverterKva} kVA` : 'Not provided'}</strong>
-            </div>
-            <div className="results-row">
-              <span>Battery</span>
-              <strong>{answers.quote.batteryKwh ? `${answers.quote.batteryKwh} kWh` : 'Not provided'}</strong>
-            </div>
-            <div className="results-row">
-              <span>Panels</span>
-              <strong>{answers.quote.panelCount ? `${answers.quote.panelCount} panels` : 'Not provided'}</strong>
-            </div>
+            <p className="text-xs text-amber-700 mt-3">We&apos;ll compare your quote against Zimbabwe market tiers once you generate the BOQ.</p>
           </div>
         </div>
       )}
@@ -810,53 +810,68 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
             transition={{ duration: 0.2 }}
-            className="form-grid"
+            className="space-y-6"
           >
+            {/* Panel brands */}
             <div>
-              <label className="field-label">Solar Panel Brand</label>
-              <div className="pill-grid">
-                {[
-                  { id: 'ja_solar', label: 'JA Solar' },
-                  { id: 'canadian_solar', label: 'Canadian Solar' },
-                  { id: 'no_pref', label: 'No preference' },
-                  { id: 'cheapest', label: 'Cheapest available' },
-                ].map((b) => (
-                  <button key={b.id} type="button" className={`pill ${panelBrand === b.id ? 'pill--active' : ''}`} onClick={() => setPanelBrand(b.id)}>
-                    {b.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div>
-              <label className="field-label">Inverter Brand</label>
-              <div className="pill-grid">
-                {[
-                  { id: 'deye',    label: 'Deye' },
-                  { id: 'victron', label: 'Victron' },
-                  { id: 'solarmd', label: 'SolarMD' },
-                  { id: 'no_pref', label: 'No preference' },
-                ].map((b) => (
-                  <button key={b.id} type="button" className={`pill ${inverterBrand === b.id ? 'pill--active' : ''}`} onClick={() => setInverterBrand(b.id)}>
-                    {b.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div>
-              <label className="field-label">Battery Brand</label>
-              <div className="pill-grid">
-                {[
-                  { id: 'pylontech',   label: 'Pylontech' },
-                  { id: 'freedom_won', label: 'Freedom Won' },
-                  { id: 'no_pref',     label: 'No preference' },
-                ].map((b) => (
+              <label className="block text-sm font-bold text-slate-700 mb-2">Solar Panel Brand</label>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                {PANEL_BRANDS.map((b) => (
                   <button
-                    key={b.id}
+                    key={b.brand}
                     type="button"
-                    className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-sm ${batteryBrand === b.id ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'}`}
-                    onClick={() => setBatteryBrand(b.id)}
+                    className={`flex flex-col items-start p-3 rounded-xl border text-left text-sm transition-colors ${panelBrand === b.brand ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500/20' : 'border-slate-200 bg-white hover:border-blue-300'}`}
+                    onClick={() => setPanelBrand(b.brand)}
                   >
-                    {b.label}
+                    <span className="font-semibold text-slate-800">{b.label}</span>
+                    <span className="text-xs text-slate-500">{b.watt}W · ${b.pricePerPanel}/panel</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Inverter brands */}
+            <div>
+              <label className="block text-sm font-bold text-slate-700 mb-2">Inverter Brand</label>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {INVERTER_BRANDS.map((b) => {
+                  const price5kva = b.prices[5] ?? Object.values(b.prices)[0];
+                  return (
+                    <button
+                      key={b.brand}
+                      type="button"
+                      className={`flex flex-col items-start p-3 rounded-xl border text-left text-sm transition-colors ${inverterBrand === b.brand ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500/20' : 'border-slate-200 bg-white hover:border-blue-300'}`}
+                      onClick={() => setInverterBrand(b.brand)}
+                    >
+                      <div className="flex w-full items-center justify-between">
+                        <span className="font-semibold text-slate-800">{b.label}</span>
+                        <span className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${b.tier === 'budget' ? 'bg-green-100 text-green-700' : b.tier === 'premium' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'}`}>{b.tier}</span>
+                      </div>
+                      <span className="text-xs text-slate-500 mt-1">{b.description}</span>
+                      <span className="text-xs font-medium text-slate-600 mt-1">~${price5kva} for 5kVA</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Battery brands */}
+            <div>
+              <label className="block text-sm font-bold text-slate-700 mb-2">Battery Brand</label>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {BATTERY_BRANDS.map((b) => (
+                  <button
+                    key={b.brand}
+                    type="button"
+                    className={`flex flex-col items-start p-3 rounded-xl border text-left text-sm transition-colors ${batteryBrand === b.brand ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500/20' : 'border-slate-200 bg-white hover:border-blue-300'}`}
+                    onClick={() => setBatteryBrand(b.brand)}
+                  >
+                    <div className="flex w-full items-center justify-between">
+                      <span className="font-semibold text-slate-800">{b.label}</span>
+                      <span className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${b.tier === 'budget' ? 'bg-green-100 text-green-700' : b.tier === 'premium' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'}`}>{b.tier}</span>
+                    </div>
+                    <span className="text-xs text-slate-500 mt-1">{b.description}</span>
+                    <span className="text-xs font-medium text-slate-600 mt-1">${b.unitPrice} per {b.unitKwh}kWh unit · ${b.pricePerKwh}/kWh</span>
                   </button>
                 ))}
               </div>
@@ -875,11 +890,11 @@ export default function SolarQuickWizard({ onChange, isContractor = false, onSav
             className="grid gap-2"
           >
             {[
-              { id: 'transport',   label: 'Equipment delivery / transport', val: includeTransport, set: setIncludeTransport },
-              { id: 'install',     label: 'Installation labor (25% of hardware)', val: includeInstall, set: setIncludeInstall },
+              { id: 'transport',   label: 'Equipment delivery / transport ($80)', val: includeTransport, set: setIncludeTransport },
+              { id: 'install',     label: 'Installation labor (20% of hardware)', val: includeInstall, set: setIncludeInstall },
               { id: 'contingency', label: 'Contingency (5%)', val: includeContingency, set: setIncludeContingency },
             ].map((opt) => (
-              <label key={opt.id} className="flex items-center gap-3 rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:bg-slate-50">
+              <label key={opt.id} className="flex items-center gap-3 rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:bg-slate-50 cursor-pointer">
                 <input type="checkbox" checked={opt.val} onChange={(e) => opt.set(e.target.checked)} className="h-5 w-5 rounded border-slate-300 text-blue-600 focus:ring-blue-600 focus:ring-offset-0" />
                 <span className="font-medium text-slate-800">{opt.label}</span>
               </label>

--- a/src/lib/quick-projects/borehole/calculations.ts
+++ b/src/lib/quick-projects/borehole/calculations.ts
@@ -1,43 +1,707 @@
 import { makeItem, type Answers, type BOQItem } from '../engine/types';
-import { BOREHOLE_PRICES as P } from './catalog';
+import { BOREHOLE_PRICES as P, LOCATION_DEFAULTS } from './catalog';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function needsWork(a: Answers, work: string): boolean {
+  const w = a.existing_work_needed;
+  return Array.isArray(w) && w.includes(work);
+}
+
+/** Match solar kit to depth using TSG Projects pump-to-depth matrix. */
+function getSolarKit(depth: number): { key: keyof typeof P; desc: string } {
+  if (depth > 120) return { key: 'solar_kit_3hp', desc: 'Solar pump kit — 3.0 HP (deep / commercial borehole)' };
+  if (depth > 100) return { key: 'solar_kit_2hp', desc: 'Solar pump kit — 2.0 HP (deep borehole)' };
+  if (depth > 80)  return { key: 'solar_kit_15hp', desc: 'Solar pump kit — 1.5 HP (high yield)' };
+  if (depth > 50)  return { key: 'solar_kit_1hp', desc: 'Solar pump kit — 1.0 HP' };
+  if (depth > 30)  return { key: 'solar_kit_075hp', desc: 'Solar pump kit — 0.75 HP' };
+  return { key: 'solar_kit_05hp', desc: 'Solar pump kit — 0.5 HP' };
+}
+
+/** Match hybrid kit to depth. */
+function getHybridKit(depth: number): { key: keyof typeof P; desc: string } {
+  if (depth > 100) return { key: 'hybrid_kit_2hp', desc: 'Hybrid AC/DC pump kit — 2.0 HP (deep borehole)' };
+  if (depth > 60)  return { key: 'hybrid_kit_15hp', desc: 'Hybrid AC/DC pump kit — 1.5 HP' };
+  return { key: 'hybrid_kit_1hp', desc: 'Hybrid AC/DC pump kit — 1.0 HP (auto solar/grid switching)' };
+}
+
+/** Match electric kit to depth using TSG Projects matrix. */
+function getElectricKit(depth: number): { key: keyof typeof P; desc: string } {
+  if (depth > 120) return { key: 'electric_kit_3hp', desc: 'Electric submersible pump — 3.0 HP (deep borehole)' };
+  if (depth > 100) return { key: 'electric_kit_2hp', desc: 'Electric submersible pump — 2.0 HP' };
+  if (depth > 50)  return { key: 'electric_kit_1hp', desc: 'Electric submersible pump — 1.0 HP' };
+  return { key: 'electric_kit_075hp', desc: 'Electric submersible pump — 0.75 HP' };
+}
+
+function getMobilizationCost(areaType: string, distanceKm?: number): number {
+  // If user provided a specific distance, use formula: base + max(0, distance - freeRadius) × rate
+  if (distanceKm && distanceKm > 0) {
+    const extraKm = Math.max(0, distanceKm - P.mobilization_free_radius_km);
+    return P.mobilization_base + extraKm * P.mobilization_per_km;
+  }
+  // Otherwise estimate by area type
+  if (areaType === 'rural') return P.mobilization_base + 40 * P.mobilization_per_km;
+  if (areaType === 'peri_urban') return P.mobilization_base + 15 * P.mobilization_per_km;
+  return P.mobilization_base;
+}
+
+// ─── Main Calculator ─────────────────────────────────────────────────────────
 
 export function calculateBoreholeBOQ(answers: Answers): BOQItem[] {
-  const depth = parseInt(answers.drilling_depth as string) || 60;
-  const casingType = (answers.casing_type as string) || 'upvc';
-  const casingDia = (answers.casing_diameter as string) || '100mm';
-  const pumpType = (answers.pump_type as string) || 'submersible';
-  const risingMaterial = (answers.rising_material as string) || 'hdpe';
-  const risingDia = (answers.rising_diameter as string) || '32mm';
+  if (answers.estimate_mode === 'budget') return calculateBudgetBOQ(answers);
+  if (answers.project_scope === 'quick_service') return calculateQuickServiceBOQ(answers);
+  if (answers.project_scope === 'existing_borehole') return calculateExistingBoreholeBOQ(answers);
+  return calculateNewBoreholeBOQ(answers);
+}
 
-  const casingKey = `casing_${casingType}_${casingDia.replace('mm','')}` as keyof typeof P;
-  const risingKey = `rising_${risingMaterial}_${risingDia.replace('mm','')}` as keyof typeof P;
-  const cableKey = depth > 50 ? 'cable_40' : 'cable_25';
-  const pumpKey = pumpType === 'hand' ? 'pump_hand' :
-                  depth > 60 ? 'pump_sub_15' :
-                  depth > 30 ? 'pump_sub_075' : 'pump_sub_055';
+// ═══════════════════════════════════════════════════════════════════════════════
+// NEW BOREHOLE
+// ═══════════════════════════════════════════════════════════════════════════════
 
-  const gravel = +(depth * 0.03).toFixed(1);
+function calculateNewBoreholeBOQ(answers: Answers): BOQItem[] {
+  const isQuick = answers.estimate_mode === 'quick';
+  const purpose = (answers.borehole_purpose as string) || 'domestic';
+  const location = (answers.project_location as string) || 'other';
+  const areaType = (answers.area_type as string) || 'peri_urban';
+  const locMeta = LOCATION_DEFAULTS[location] || LOCATION_DEFAULTS.other;
 
-  const items: BOQItem[] = [
-    makeItem('bh_drilling',  'Drilling',  `Borehole drilling (all-in rate)`,     depth,       'm',    P.drilling_per_m),
-    makeItem('bh_casing',    'Casing',    `${casingType.toUpperCase()} casing ${casingDia}`, depth, 'm', P[casingKey] ?? 12),
-    makeItem('bh_gravel',    'Casing',    'Gravel pack (filter)',                 gravel,      'm³',   P.gravel_pack),
-    makeItem('bh_wellhead',  'Wellhead',  'Wellhead assembly',                   1,           'each', P.wellhead),
-    makeItem('bh_rising',    'Pipework',  `${risingMaterial.toUpperCase()} rising main ${risingDia}`, depth + 5, 'm', P[risingKey] ?? 3.50),
-  ];
+  // ── Resolve drilling depth ──────────────────────────────────────────────
+  const depth = parseInt(answers.drilling_depth as string) || locMeta.depth;
 
-  if (pumpType !== 'none') {
-    items.push(makeItem('bh_pump', 'Pump', pumpType === 'hand' ? 'Afridev hand pump' : `Submersible pump (${depth > 60 ? '1.5' : depth > 30 ? '0.75' : '0.55'}kW)`, 1, 'each', P[pumpKey]));
-    if (pumpType === 'submersible') {
-      items.push(makeItem('bh_cable', 'Electrical', `3-core pump cable ${depth > 50 ? '4' : '2.5'}mm²`, depth + 10, 'm', P[cableKey]));
+  // ── Resolve casing ─────────────────────────────────────────────────────
+  const casingMaterial = isQuick ? 'upvc' : (answers.casing_material as string) || 'upvc';
+  const casingClass = isQuick
+    ? depth > 60 || purpose !== 'domestic' ? 'class_10' : 'class_6'
+    : (answers.casing_class as string) || 'class_6';
+  const casingDiameter = isQuick
+    ? purpose === 'domestic' ? '140mm' : '180mm'
+    : (answers.casing_diameter as string) || '140mm';
+
+  // ── Resolve ground conditions ───────────────────────────────────────────
+  const ground = isQuick ? 'not_sure' : (answers.ground_conditions as string) || 'not_sure';
+  const isSandy = ground === 'sandy';
+  const doubleCasing = isQuick ? false : Boolean(answers.double_casing);
+
+  // ── Resolve water system ────────────────────────────────────────────────
+  const systemScope =
+    (answers.system_scope as string) || (isQuick ? 'complete_system' : 'drilling_only');
+  const pumpPower = isQuick ? 'solar' : (answers.pump_power_source as string) || 'solar';
+  const tankCapacity = isQuick
+    ? purpose === 'domestic' ? '5000' : '10000'
+    : (answers.tank_capacity as string) || '5000';
+  const standChoice = isQuick ? 'combo' : (answers.include_tank_stand as string) || 'standard';
+  const customStandHeight = parseInt(answers.tank_stand_height as string) || 4;
+
+  // ── Resolve site distance ──────────────────────────────────────────────
+  const siteDistance = parseInt(answers.site_distance_km as string) || 0;
+
+  // ── Resolve services ───────────────────────────────────────────────────
+  const includeSiteSurvey = isQuick
+    ? true
+    : answers.site_survey_done !== 'yes' && Boolean(answers.include_site_survey ?? true);
+  const includeFlushing = isQuick ? true : Boolean(answers.include_flushing ?? true);
+  const includeYieldTest = isQuick ? true : Boolean(answers.include_yield_test ?? true);
+  const waterQualityLevel = isQuick
+    ? purpose === 'commercial' ? 'full' : 'basic'
+    : (answers.water_quality_level as string) || 'none';
+  const includeZinwaPermit = isQuick
+    ? true
+    : answers.has_permits !== 'yes' && Boolean(answers.include_zinwa_permit ?? true);
+  const includeCouncilFee = isQuick
+    ? true
+    : answers.has_permits !== 'yes' && Boolean(answers.include_council_fee ?? true);
+  const includeMobilization = isQuick ? true : Boolean(answers.include_mobilization ?? true);
+  const includePumpInstall = isQuick
+    ? systemScope !== 'drilling_only'
+    : Boolean(answers.include_pump_install ?? true);
+  const includePurification = isQuick
+    ? purpose === 'commercial'
+    : Boolean(answers.include_purification);
+
+  // ── Resolve security ───────────────────────────────────────────────────
+  const includeAntitheft = !isQuick && Boolean(answers.include_antitheft_brackets);
+  const antitheftQty = parseInt(answers.antitheft_bracket_qty as string) || 6;
+  const includeSecurityCage = !isQuick && Boolean(answers.include_security_cage);
+  const securityCageCost = parseInt(answers.security_cage_cost as string) || P.security_cage_estimate;
+
+  // ════════════════════════════════════════════════════════════════════════
+  // BUILD BOQ
+  // ════════════════════════════════════════════════════════════════════════
+
+  const items: BOQItem[] = [];
+
+  // ── 1. Drilling ──────────────────────────────────────────────────────────
+  const useMudDrilling = isSandy;
+  const drillingRate = useMudDrilling ? P.mud_drilling_per_m : P.drilling_per_m;
+  items.push(
+    makeItem(
+      'bh_drilling', 'Drilling',
+      useMudDrilling ? 'Borehole drilling — mud drilling (sandy soil)' : 'Borehole drilling',
+      depth, 'm', drillingRate,
+    ),
+  );
+
+  // ── 2. Casing ────────────────────────────────────────────────────────────
+  const casingPricePerM = resolveCasingPrice(casingMaterial, casingClass, casingDiameter);
+  const casingDesc = formatCasingDesc(casingMaterial, casingClass, casingDiameter);
+  items.push(makeItem('bh_casing', 'Casing', casingDesc, depth, 'm', casingPricePerM));
+
+  if (doubleCasing || (isSandy && !isQuick)) {
+    items.push(
+      makeItem('bh_double_casing', 'Casing', 'Double casing — top section (sandy soil protection)', 10, 'm', P.double_casing_per_m),
+    );
+  }
+
+  // ── 3. Gravel pack & wellhead ────────────────────────────────────────────
+  const gravelM3 = +(depth * 0.03).toFixed(1);
+  items.push(makeItem('bh_gravel', 'Casing', 'Gravel pack (filter)', gravelM3, 'm³', P.gravel_pack_per_m3));
+  items.push(makeItem('bh_wellhead', 'Wellhead', 'Wellhead assembly & sanitary seal', 1, 'each', P.wellhead_assembly));
+
+  // ── 4. Pump ──────────────────────────────────────────────────────────────
+  if (systemScope !== 'drilling_only') {
+    addPumpItems(items, pumpPower, depth, purpose);
+  }
+
+  // ── 5. Tank & stand ──────────────────────────────────────────────────────
+  if (systemScope === 'complete_system') {
+    addTankItems(items, tankCapacity, standChoice, customStandHeight);
+  }
+
+  // ── 6. Site security ─────────────────────────────────────────────────────
+  if (includeAntitheft) {
+    items.push(makeItem('bh_antitheft', 'Site Security', 'Anti-theft brackets for solar panels', antitheftQty, 'pcs', P.antitheft_brackets, { optional: true }));
+  }
+  if (includeSecurityCage) {
+    items.push(makeItem('bh_security_cage', 'Site Security', 'Security cage — pump/inverter/battery protection', 1, 'each', securityCageCost, { optional: true }));
+  }
+
+  // ── 7. Professional services ───────────────────────────────────────────
+  if (includeSiteSurvey) {
+    const surveyKey = `site_survey_${areaType}` as keyof typeof P;
+    items.push(
+      makeItem('bh_survey', 'Professional Services', 'Site survey — locating the best drilling point', 1, 'each', (P[surveyKey] as number) || P.site_survey_peri_urban, { optional: true }),
+    );
+  }
+  if (includeFlushing) {
+    items.push(makeItem('bh_flushing', 'Professional Services', 'Borehole flushing & cleaning', 1, 'each', P.borehole_flushing, { optional: true }));
+  }
+  if (includeYieldTest) {
+    items.push(makeItem('bh_yield', 'Professional Services', 'Water yield / capacity test', 1, 'each', P.yield_test, { optional: true }));
+  }
+  addWaterQualityItems(items, waterQualityLevel);
+  if (includePurification) {
+    items.push(makeItem('bh_purification', 'Water Treatment', 'Water purification system', 1, 'each', P.purification_system, { optional: true }));
+  }
+
+  // ── 8. Permits & compliance ──────────────────────────────────────────────
+  if (includeZinwaPermit) {
+    items.push(makeItem('bh_zinwa', 'Permits & Compliance', 'ZINWA drilling permit (Form GW1)', 1, 'each', P.zinwa_permit_gw1, { optional: true }));
+  }
+  if (includeCouncilFee) {
+    const councilFee = locMeta.councilFee;
+    const locLabel = location === 'other' ? 'estimated average' : location.charAt(0).toUpperCase() + location.slice(1);
+    items.push(makeItem('bh_council', 'Permits & Compliance', `Local council approval fee (${locLabel})`, 1, 'each', councilFee, { optional: true }));
+  }
+
+  // ── 9. Mobilization & labour ───────────────────────────────────────────
+  if (includeMobilization) {
+    const mobilizationCost = getMobilizationCost(areaType, siteDistance);
+    const distNote = siteDistance > 0
+      ? `${siteDistance} km from depot — ${Math.max(0, siteDistance - P.mobilization_free_radius_km)} km beyond free radius`
+      : areaType === 'urban' ? `Within ${P.mobilization_free_radius_km} km — base rate` : `Estimated transport to ${areaType.replace('_', '-')} site`;
+    items.push(
+      makeItem('bh_mobilization', 'Transport & Logistics', 'Drilling rig transport to site', 1, 'each', mobilizationCost, {
+        optional: true,
+        notes: distNote,
+      }),
+    );
+  }
+  if (includePumpInstall && systemScope !== 'drilling_only') {
+    items.push(makeItem('bh_pump_install', 'Transport & Logistics', 'Pump installation labour', 1, 'each', P.pump_installation, { optional: true }));
+  }
+
+  return items;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// EXISTING BOREHOLE
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function calculateExistingBoreholeBOQ(answers: Answers): BOQItem[] {
+  const isQuick = answers.estimate_mode === 'quick';
+  const purpose = (answers.borehole_purpose as string) || 'domestic';
+  const areaType = (answers.area_type as string) || 'peri_urban';
+
+  const items: BOQItem[] = [];
+  let needsMobilization = false;
+
+  // ── Additional Drilling ─────────────────────────────────────────────────
+  if (needsWork(answers, 'additional_drilling')) {
+    const extraMetres = parseInt(answers.additional_metres as string) || 20;
+    items.push(
+      makeItem('ex_drilling', 'Drilling', 'Additional drilling — deepening existing borehole', extraMetres, 'm', P.drilling_per_m),
+    );
+    // Extra casing for the new section
+    const casingPricePerM = isQuick
+      ? P.casing_upvc_140_c6
+      : resolveCasingPrice(
+          (answers.casing_material as string) || 'upvc',
+          (answers.casing_class as string) || 'class_6',
+          (answers.casing_diameter as string) || '140mm',
+        );
+    const casingDesc = isQuick
+      ? 'PVC casing 140mm (Class 6 — standard)'
+      : formatCasingDesc(
+          (answers.casing_material as string) || 'upvc',
+          (answers.casing_class as string) || 'class_6',
+          (answers.casing_diameter as string) || '140mm',
+        );
+    items.push(
+      makeItem('ex_casing_extend', 'Casing', `${casingDesc} — extension`, extraMetres, 'm', casingPricePerM),
+    );
+    needsMobilization = true;
+  }
+
+  // ── Casing Replacement ──────────────────────────────────────────────────
+  if (needsWork(answers, 'casing_replacement')) {
+    const replaceLength = parseInt(answers.casing_replacement_length as string) || 40;
+    const casingMaterial = (answers.casing_material as string) || 'upvc';
+    const casingClass = (answers.casing_class as string) || 'class_6';
+    const casingDiameter = (answers.casing_diameter as string) || '140mm';
+    const casingPricePerM = resolveCasingPrice(casingMaterial, casingClass, casingDiameter);
+    const casingDesc = formatCasingDesc(casingMaterial, casingClass, casingDiameter);
+
+    // Old casing removal labour
+    items.push(
+      makeItem('ex_casing_removal', 'Casing', 'Remove old casing', replaceLength, 'm', 3.0, {
+        notes: 'Labour cost for pulling and disposing of old casing',
+      }),
+    );
+    // New casing
+    items.push(
+      makeItem('ex_casing_new', 'Casing', `${casingDesc} — replacement`, replaceLength, 'm', casingPricePerM),
+    );
+    // Gravel pack for replacement
+    const gravelM3 = +(replaceLength * 0.03).toFixed(1);
+    items.push(makeItem('ex_gravel', 'Casing', 'Gravel pack (filter)', gravelM3, 'm³', P.gravel_pack_per_m3));
+
+    needsMobilization = true;
+  }
+
+  // ── Pump Replacement ────────────────────────────────────────────────────
+  if (needsWork(answers, 'pump_replacement')) {
+    const depth = parseInt(answers.existing_borehole_depth as string) || 50;
+    const pumpPower = (answers.pump_power_source as string) || 'solar';
+
+    // Pump retrieval (old pump must come out first)
+    items.push(
+      makeItem('ex_pump_retrieval', 'Pump & Power', 'Retrieve existing pump from borehole', 1, 'each', P.pump_retrieval),
+    );
+
+    // New pump
+    addPumpItems(items, pumpPower, depth, purpose, 'ex_');
+
+    // Installation labour
+    items.push(
+      makeItem('ex_pump_install', 'Transport & Logistics', 'Pump installation labour', 1, 'each', P.pump_installation, { optional: true }),
+    );
+
+    needsMobilization = true;
+  }
+
+  // ── Pump Retrieval Only ─────────────────────────────────────────────────
+  if (needsWork(answers, 'pump_retrieval') && !needsWork(answers, 'pump_replacement')) {
+    items.push(
+      makeItem('ex_pump_retrieval', 'Professional Services', 'Retrieve stuck or failed pump from borehole', 1, 'each', P.pump_retrieval),
+    );
+    needsMobilization = true;
+  }
+
+  // ── Tank Addition ───────────────────────────────────────────────────────
+  if (needsWork(answers, 'tank_addition')) {
+    const tankCapacity = isQuick
+      ? purpose === 'domestic' ? '5000' : '10000'
+      : (answers.tank_capacity as string) || '5000';
+    const standChoice = isQuick ? 'combo' : (answers.include_tank_stand as string) || 'standard';
+    const customHeight = parseInt(answers.tank_stand_height as string) || 4;
+
+    addTankItems(items, tankCapacity, standChoice, customHeight, 'ex_');
+  }
+
+  // ── Maintenance / Testing ───────────────────────────────────────────────
+  if (needsWork(answers, 'maintenance')) {
+    const includeFlushing = isQuick ? true : Boolean(answers.include_flushing ?? true);
+    const includeYieldTest = isQuick ? true : Boolean(answers.include_yield_test ?? true);
+    const waterQualityLevel = isQuick
+      ? purpose === 'commercial' ? 'full' : 'basic'
+      : (answers.water_quality_level as string) || 'none';
+
+    if (includeFlushing) {
+      items.push(makeItem('ex_flushing', 'Professional Services', 'Borehole flushing & cleaning', 1, 'each', P.borehole_flushing, { optional: true }));
+    }
+    if (includeYieldTest) {
+      items.push(makeItem('ex_yield', 'Professional Services', 'Water yield / capacity test', 1, 'each', P.yield_test, { optional: true }));
+    }
+    addWaterQualityItems(items, waterQualityLevel, 'ex_');
+
+    if (purpose === 'commercial' && (isQuick || Boolean(answers.include_purification))) {
+      items.push(makeItem('ex_purification', 'Water Treatment', 'Water purification system', 1, 'each', P.purification_system, { optional: true }));
     }
   }
 
-  // Optional
-  if (answers.include_mobilization) items.push(makeItem('bh_mob',   'Site Work', 'Rig mobilization',         1, 'each', P.mobilization,      { optional: true }));
-  if (answers.include_pump_test)    items.push(makeItem('bh_test',  'Site Work', 'Pump test & development',  1, 'each', P.pump_test,         { optional: true }));
-  if (answers.include_water_test)   items.push(makeItem('bh_wtest', 'Site Work', 'Water quality lab test',   1, 'each', P.water_quality_test,{ optional: true }));
-  if (answers.include_pump_install) items.push(makeItem('bh_inst',  'Site Work', 'Pump installation labour', 1, 'each', P.pump_install,      { optional: true }));
+  // ── Mobilization (for any work requiring a rig or crew on-site) ─────────
+  if (needsMobilization) {
+    const mobilizationCost = getMobilizationCost(areaType);
+    items.push(
+      makeItem('ex_mobilization', 'Transport & Logistics', 'Rig / crew transport to site', 1, 'each', mobilizationCost, {
+        optional: true,
+        notes: areaType === 'urban' ? `Within ${P.mobilization_free_radius_km} km — base rate` : `Includes estimated transport to ${areaType.replace('_', '-')} site`,
+      }),
+    );
+  }
 
   return items;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// QUICK SERVICE (flushing, testing, retrieval only — no drilling)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function calculateQuickServiceBOQ(answers: Answers): BOQItem[] {
+  const services = (answers.quick_service_type as string[]) || [];
+  const areaType = (answers.area_type as string) || 'peri_urban';
+  const items: BOQItem[] = [];
+
+  if (services.includes('flushing')) {
+    items.push(makeItem('qs_flushing', 'Professional Services', 'Borehole flushing & cleaning', 1, 'each', P.borehole_flushing));
+  }
+  if (services.includes('yield_test')) {
+    items.push(makeItem('qs_yield', 'Professional Services', 'Water yield / capacity test', 1, 'each', P.yield_test));
+  }
+  if (services.includes('water_test_basic')) {
+    items.push(makeItem('qs_wq_basic', 'Professional Services', 'Water quality test — bacteriological', 1, 'each', P.water_test_bacteriological));
+  }
+  if (services.includes('water_test_full')) {
+    items.push(makeItem('qs_wq_bact', 'Professional Services', 'Water quality test — bacteriological', 1, 'each', P.water_test_bacteriological));
+    items.push(makeItem('qs_wq_chem', 'Professional Services', 'Water quality test — chemical analysis', 1, 'each', P.water_test_chemical));
+  }
+  if (services.includes('pump_retrieval')) {
+    items.push(makeItem('qs_retrieval', 'Professional Services', 'Retrieve stuck or failed pump', 1, 'each', P.pump_retrieval));
+  }
+  if (services.includes('purification')) {
+    items.push(makeItem('qs_purification', 'Water Treatment', 'Water purification system', 1, 'each', P.purification_system));
+  }
+
+  // Mobilization for on-site services
+  if (services.includes('flushing') || services.includes('pump_retrieval')) {
+    const mobilizationCost = getMobilizationCost(areaType);
+    items.push(
+      makeItem('qs_mobilization', 'Transport & Logistics', 'Crew transport to site', 1, 'each', mobilizationCost, {
+        optional: true,
+        notes: areaType === 'urban' ? `Within ${P.mobilization_free_radius_km} km — base rate` : `Includes transport to ${areaType.replace('_', '-')} site`,
+      }),
+    );
+  }
+
+  return items;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BUDGET EXPLORER — auto-generate best-fit package within a budget
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function calculateBudgetBOQ(answers: Answers): BOQItem[] {
+  const budget = parseFloat(answers.budget_amount as string) || 3000;
+  const purpose = (answers.borehole_purpose as string) || 'domestic';
+  const location = (answers.project_location as string) || 'other';
+  const areaType = (answers.area_type as string) || 'peri_urban';
+  const locMeta = LOCATION_DEFAULTS[location] || LOCATION_DEFAULTS.other;
+
+  const items: BOQItem[] = [];
+  let remaining = budget;
+
+  // ── 1. Mandatory: ZINWA permit ─────────────────────────────────────────
+  items.push(makeItem('bg_zinwa', 'Permits & Compliance', 'ZINWA drilling permit (Form GW1)', 1, 'each', P.zinwa_permit_gw1));
+  remaining -= P.zinwa_permit_gw1;
+
+  // ── 2. Mandatory: Council fee ──────────────────────────────────────────
+  items.push(makeItem('bg_council', 'Permits & Compliance', `Local council approval fee`, 1, 'each', locMeta.councilFee));
+  remaining -= locMeta.councilFee;
+
+  // ── 3. Mandatory: Mobilization ─────────────────────────────────────────
+  const mobilCost = getMobilizationCost(areaType);
+  items.push(makeItem('bg_mobilization', 'Transport & Logistics', 'Drilling rig transport to site', 1, 'each', mobilCost));
+  remaining -= mobilCost;
+
+  // ── 4. Mandatory: Site survey ──────────────────────────────────────────
+  const surveyKey = `site_survey_${areaType}` as keyof typeof P;
+  const surveyCost = (P[surveyKey] as number) || P.site_survey_peri_urban;
+  items.push(makeItem('bg_survey', 'Professional Services', 'Site survey', 1, 'each', surveyCost));
+  remaining -= surveyCost;
+
+  // ── 5. Drilling — use user-selected depth (default 40m) ─────────────────
+  const depth = parseInt(answers.budget_depth as string) || 40;
+  const drillingCost = depth * P.drilling_per_m;
+  items.push(makeItem('bg_drilling', 'Drilling', 'Borehole drilling', depth, 'm', P.drilling_per_m));
+  remaining -= drillingCost;
+
+  // ── 6. Casing — pick best grade that fits ──────────────────────────────
+  const casingDiameter = purpose === 'domestic' ? '140mm' : '180mm';
+  // Try from premium down
+  const casingOptions: Array<{ cls: string; label: string }> = [
+    { cls: 'class_10', label: 'Class 10 — premium' },
+    { cls: 'class_9', label: 'Class 9 — mid-grade' },
+    { cls: 'class_6', label: 'Class 6 — standard' },
+  ];
+  let chosenCasing = casingOptions[2]; // default to Class 6
+  for (const opt of casingOptions) {
+    const price = resolveCasingPrice('upvc', opt.cls, casingDiameter);
+    if (price * depth <= remaining * 0.3) { // allocate up to 30% remaining for casing
+      chosenCasing = opt;
+      break;
+    }
+  }
+  const casingPrice = resolveCasingPrice('upvc', chosenCasing.cls, casingDiameter);
+  const casingCost = casingPrice * depth;
+  items.push(makeItem('bg_casing', 'Casing', `PVC casing ${casingDiameter} (${chosenCasing.label})`, depth, 'm', casingPrice));
+  remaining -= casingCost;
+
+  // ── 7. Gravel pack & wellhead ──────────────────────────────────────────
+  const gravelM3 = +(depth * 0.03).toFixed(1);
+  const gravelCost = gravelM3 * P.gravel_pack_per_m3;
+  items.push(makeItem('bg_gravel', 'Casing', 'Gravel pack (filter)', gravelM3, 'm³', P.gravel_pack_per_m3));
+  items.push(makeItem('bg_wellhead', 'Wellhead', 'Wellhead assembly & sanitary seal', 1, 'each', P.wellhead_assembly));
+  remaining -= gravelCost + P.wellhead_assembly;
+
+  // ── 8. Pump — pick best type within remaining budget ───────────────────
+  // Try solar first, then hybrid, then electric, then hand pump
+  type PumpOption = { type: string; key: keyof typeof P; desc: string };
+  const pumpOptions: PumpOption[] = [];
+
+  const solar = getSolarKit(depth);
+  pumpOptions.push({ type: 'solar', key: solar.key, desc: solar.desc });
+
+  const hybrid = getHybridKit(depth);
+  pumpOptions.push({ type: 'hybrid', key: hybrid.key, desc: hybrid.desc });
+
+  const electric = getElectricKit(depth);
+  pumpOptions.push({ type: 'electric', key: electric.key, desc: electric.desc });
+
+  pumpOptions.push({ type: 'hand', key: 'pump_hand_afridev', desc: 'Afridev hand pump' });
+
+  let pumpChosen: PumpOption | null = null;
+  for (const opt of pumpOptions) {
+    const cost = P[opt.key] as number;
+    if (cost <= remaining * 0.7) { // leave 30% for tank/services
+      pumpChosen = opt;
+      break;
+    }
+  }
+
+  if (pumpChosen) {
+    const pumpCost = P[pumpChosen.key] as number;
+    items.push(makeItem('bg_pump', 'Pump & Power', pumpChosen.desc, 1, pumpChosen.type === 'hand' ? 'each' : 'kit', pumpCost, {
+      notes: pumpChosen.type === 'solar' ? 'Includes submersible pump, solar panels, controller, and mounting frame' :
+             pumpChosen.type === 'hybrid' ? 'Auto-switches between solar and ZESA grid power' : undefined,
+    }));
+    remaining -= pumpCost;
+
+    // Rising main (not for hand pumps)
+    if (pumpChosen.type !== 'hand') {
+      const risingDia = purpose === 'domestic' ? '25mm' : '32mm';
+      const risingKey = `rising_hdpe_${risingDia}` as keyof typeof P;
+      const risingRate = (P[risingKey] as number) || P.rising_hdpe_32mm;
+      const risingCost = (depth + 5) * risingRate;
+      items.push(makeItem('bg_rising', 'Pipework', `HDPE rising main — ${risingDia}`, depth + 5, 'm', risingRate));
+      remaining -= risingCost;
+    }
+
+    // Installation
+    items.push(makeItem('bg_pump_install', 'Transport & Logistics', 'Pump installation labour', 1, 'each', P.pump_installation));
+    remaining -= P.pump_installation;
+  }
+
+  // ── 9. Tank + stand — try combo first, then separate, then skip ────────
+  if (remaining > 500) {
+    // Try combos first (best value)
+    const tankCombos: Array<{ capacity: string; combo: keyof typeof P; label: string }> = [
+      { capacity: '10000', combo: 'combo_10000L_4m', label: '10,000L tank + 4m stand (combo)' },
+      { capacity: '5000', combo: 'combo_5000L_4m', label: '5,000L tank + 4m stand (combo)' },
+    ];
+
+    let tankAdded = false;
+    for (const tc of tankCombos) {
+      const comboCost = P[tc.combo] as number;
+      if (comboCost <= remaining) {
+        items.push(makeItem('bg_tank_combo', 'Storage', tc.label, 1, 'set', comboCost, {
+          notes: 'Bundled package — discounted vs buying separately',
+        }));
+        remaining -= comboCost;
+        tankAdded = true;
+        break;
+      }
+    }
+
+    // If no combo fits, try separate tank without stand
+    if (!tankAdded) {
+      const tankOptions: Array<{ capacity: string; key: keyof typeof P; label: string }> = [
+        { capacity: '5000', key: 'tank_5000L', label: 'Water tank — 5,000 litres' },
+        { capacity: '2500', key: 'tank_2500L', label: 'Water tank — 2,500 litres' },
+        { capacity: '2000', key: 'tank_2000L', label: 'Water tank — 2,000 litres' },
+      ];
+      for (const t of tankOptions) {
+        const cost = P[t.key] as number;
+        if (cost <= remaining) {
+          items.push(makeItem('bg_tank', 'Storage', t.label, 1, 'each', cost));
+          remaining -= cost;
+          // Try to add a stand
+          if (remaining >= P.tank_stand_4m) {
+            items.push(makeItem('bg_stand', 'Storage', 'Steel tank stand — 4 m elevated', 1, 'each', P.tank_stand_4m));
+            remaining -= P.tank_stand_4m;
+          }
+          tankAdded = true;
+          break;
+        }
+      }
+    }
+  }
+
+  // ── 10. Post-drilling services (add what fits) ─────────────────────────
+  if (remaining >= P.borehole_flushing) {
+    items.push(makeItem('bg_flushing', 'Professional Services', 'Borehole flushing & cleaning', 1, 'each', P.borehole_flushing));
+    remaining -= P.borehole_flushing;
+  }
+  if (remaining >= P.yield_test) {
+    items.push(makeItem('bg_yield', 'Professional Services', 'Water yield / capacity test', 1, 'each', P.yield_test));
+    remaining -= P.yield_test;
+  }
+  if (remaining >= P.water_test_bacteriological) {
+    items.push(makeItem('bg_wq_basic', 'Professional Services', 'Water quality test — bacteriological', 1, 'each', P.water_test_bacteriological));
+    remaining -= P.water_test_bacteriological;
+  }
+
+  return items;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SHARED HELPERS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function resolveCasingPrice(material: string, cls: string, diameter: string): number {
+  if (material === 'steel') {
+    return diameter === '180mm' ? P.casing_steel_180 : P.casing_steel_140;
+  }
+  const classKey = cls === 'class_10' ? 'c10' : cls === 'class_9' ? 'c9' : 'c6';
+  const diaKey = diameter === '180mm' ? '180' : '140';
+  const key = `casing_upvc_${diaKey}_${classKey}` as keyof typeof P;
+  return (P[key] as number) ?? P.casing_upvc_140_c6;
+}
+
+const CLASS_LABELS: Record<string, string> = {
+  class_6: 'Class 6 — standard',
+  class_9: 'Class 9 — mid-grade',
+  class_10: 'Class 10 — premium',
+};
+
+function formatCasingDesc(material: string, cls: string, diameter: string): string {
+  if (material === 'steel') return `Steel casing ${diameter}`;
+  return `PVC casing ${diameter} (${CLASS_LABELS[cls] || 'Class 6 — standard'})`;
+}
+
+function addPumpItems(items: BOQItem[], pumpPower: string, depth: number, purpose: string, prefix = 'bh_'): void {
+  if (pumpPower === 'solar') {
+    const { key, desc } = getSolarKit(depth);
+    items.push(
+      makeItem(`${prefix}pump`, 'Pump & Power', desc, 1, 'kit', P[key] as number, {
+        notes: `Includes submersible pump, solar panels, controller, and mounting frame. Solar array: ${Math.ceil((P[key] as number) * 0.4)}W+ recommended.`,
+      }),
+    );
+  } else if (pumpPower === 'hybrid') {
+    const { key, desc } = getHybridKit(depth);
+    items.push(
+      makeItem(`${prefix}pump`, 'Pump & Power', desc, 1, 'kit', P[key] as number, {
+        notes: 'Auto-switches between solar and ZESA grid power for maximum uptime',
+      }),
+    );
+  } else if (pumpPower === 'electric') {
+    const { key, desc } = getElectricKit(depth);
+    items.push(
+      makeItem(`${prefix}pump`, 'Pump & Power', desc, 1, 'kit', P[key] as number),
+    );
+    const cableKey: keyof typeof P = depth > 50 ? 'cable_3core_40mm' : 'cable_3core_25mm';
+    items.push(
+      makeItem(`${prefix}cable`, 'Pump & Power', `Pump cable — ${depth > 50 ? '4.0' : '2.5'} mm² 3-core`, depth + 10, 'm', P[cableKey] as number),
+    );
+  } else if (pumpPower === 'hand') {
+    items.push(
+      makeItem(`${prefix}pump`, 'Pump & Power', 'Afridev hand pump', 1, 'each', P.pump_hand_afridev),
+    );
+  }
+
+  // Rising main (not for hand pumps)
+  if (pumpPower !== 'hand') {
+    const risingDia = purpose === 'domestic' ? '25mm' : '32mm';
+    const risingKey = `rising_hdpe_${risingDia}` as keyof typeof P;
+    items.push(
+      makeItem(`${prefix}rising`, 'Pipework', `HDPE rising main — ${risingDia}`, depth + 5, 'm', (P[risingKey] as number) || P.rising_hdpe_32mm),
+    );
+  }
+}
+
+function addTankItems(
+  items: BOQItem[],
+  tankCapacity: string,
+  standChoice: string,
+  customHeight: number,
+  prefix = 'bh_',
+): void {
+  // ── Combo (bundled) pricing ────────────────────────────────────────────
+  if (standChoice === 'combo') {
+    // Check for available combo
+    const comboKey = tankCapacity === '10000'
+      ? 'combo_10000L_4m'
+      : tankCapacity === '5000'
+        ? 'combo_5000L_4m'
+        : null;
+
+    if (comboKey) {
+      const comboPrice = P[comboKey as keyof typeof P] as number;
+      const standHeight = tankCapacity === '10000' ? 4 : 4;
+      items.push(
+        makeItem(`${prefix}tank_combo`, 'Storage', `${Number(tankCapacity).toLocaleString()}L tank + ${standHeight}m stand (combo)`, 1, 'set', comboPrice, {
+          notes: 'Bundled package — discounted vs buying separately',
+        }),
+      );
+      return;
+    }
+    // If no combo available for this size, fall through to separate pricing
+  }
+
+  // ── Separate pricing ───────────────────────────────────────────────────
+  const tankKey = `tank_${tankCapacity}L` as keyof typeof P;
+  items.push(
+    makeItem(`${prefix}tank`, 'Storage', `Water tank — ${Number(tankCapacity).toLocaleString()} litres`, 1, 'each', (P[tankKey] as number) || P.tank_5000L),
+  );
+  if (standChoice === 'standard') {
+    const height = tankCapacity === '10000' ? 5 : 4;
+    const standKey: keyof typeof P = height === 5 ? 'tank_stand_5m' : 'tank_stand_4m';
+    items.push(
+      makeItem(`${prefix}stand`, 'Storage', `Steel tank stand — ${height} m elevated`, 1, 'each', P[standKey] as number),
+    );
+  } else if (standChoice === 'custom') {
+    const height = customHeight || 4;
+    const standCost = height * P.tank_stand_per_m;
+    items.push(
+      makeItem(`${prefix}stand`, 'Storage', `Steel tank stand — ${height} m elevated (custom)`, 1, 'each', standCost),
+    );
+  }
+}
+
+function addWaterQualityItems(items: BOQItem[], level: string, prefix = 'bh_'): void {
+  if (level === 'basic') {
+    items.push(makeItem(`${prefix}wq_basic`, 'Professional Services', 'Water quality test — bacteriological', 1, 'each', P.water_test_bacteriological, { optional: true }));
+  } else if (level === 'full') {
+    items.push(makeItem(`${prefix}wq_bact`, 'Professional Services', 'Water quality test — bacteriological', 1, 'each', P.water_test_bacteriological, { optional: true }));
+    items.push(makeItem(`${prefix}wq_chem`, 'Professional Services', 'Water quality test — chemical analysis', 1, 'each', P.water_test_chemical, { optional: true }));
+  }
 }

--- a/src/lib/quick-projects/borehole/catalog.ts
+++ b/src/lib/quick-projects/borehole/catalog.ts
@@ -1,23 +1,125 @@
-// Borehole drilling materials catalog - Zimbabwe market Q1 2026
-export const BOREHOLE_PRICES: Record<string, number> = {
-  drilling_per_m: 28.00,        // $/m drilling (all-in)
-  casing_steel_100mm: 18.00,    // $/m steel casing 100mm
-  casing_steel_150mm: 28.00,    // $/m steel casing 150mm
-  casing_upvc_100mm: 12.00,     // $/m uPVC casing 100mm
-  casing_upvc_150mm: 18.00,     // $/m uPVC casing 150mm
-  gravel_pack: 35.00,           // $/m³ gravel pack
-  pump_sub_055: 180.00,         // each - submersible 0.55kW (up to 30m)
-  pump_sub_075: 250.00,         // each - submersible 0.75kW (up to 60m)
-  pump_sub_15: 380.00,          // each - submersible 1.5kW (up to 100m)
-  pump_hand: 320.00,            // each - hand pump (Afridev)
-  rising_hdpe_25: 2.80,         // $/m HDPE 25mm
-  rising_hdpe_32: 3.50,         // $/m HDPE 32mm
-  rising_upvc_25: 2.20,         // $/m uPVC 25mm
-  cable_25: 1.60,               // $/m 3-core 2.5mm²
-  cable_40: 2.40,               // $/m 3-core 4mm²
-  wellhead: 95.00,              // each - wellhead assembly
-  pump_test: 180.00,            // each - pump test & development
-  water_quality_test: 120.00,   // each - water quality lab test
-  mobilization: 250.00,         // each - rig mobilization
-  pump_install: 150.00,         // each - pump installation labour
+// ─── Borehole Drilling Price Catalog — Zimbabwe Market Q1 2026 ─────────────
+// Sources: Sona Solar, Borehole Experts Zim, DrillCorp, Halsteds, LAMASAT,
+//          ZINWA tariff guide, Mutare Boreholes, Arete World, Gokwe South RDC,
+//          Masvingo & Insiza by-laws, Nakiso Borehole Drilling, TSG Projects,
+//          HYBSUN Solar Pump, Sizabantu Piping, strategic analysis.
+
+export const BOREHOLE_PRICES = {
+  // ── Drilling ──────────────────────────────────────────────────────────────
+  drilling_per_m: 30.0,              // standard rate (all-in)
+  mud_drilling_per_m: 90.0,          // bentonite mud drilling — sandy / unstable soil
+
+  // ── Casing (per metre installed) ──────────────────────────────────────────
+  // PVC — 140 mm
+  casing_upvc_140_c6: 5.80,          // Class 6 — standard residential (~$35/6m)
+  casing_upvc_140_c9: 7.00,          // Class 9 — mid-grade durability
+  casing_upvc_140_c10: 7.60,         // Class 10 — premium / deep (~$46/6m)
+  // PVC — 180 mm
+  casing_upvc_180_c6: 10.00,         // Class 6 — higher yield (~$60/6m)
+  casing_upvc_180_c9: 11.00,         // Class 9 — mid-grade higher yield
+  casing_upvc_180_c10: 12.00,        // Class 10 — premium (~$72/6m)
+  // Steel casing
+  casing_steel_140: 14.0,
+  casing_steel_180: 22.0,
+  // Double-casing surcharge (top 6–20 m for sandy soil)
+  double_casing_per_m: 25.0,
+
+  // ── Gravel & Wellhead ─────────────────────────────────────────────────────
+  gravel_pack_per_m3: 35.0,
+  wellhead_assembly: 95.0,
+
+  // ── Pumps — unit only ─────────────────────────────────────────────────────
+  pump_sub_055kw: 180.0,             // submersible 0.55 kW (up to 30 m)
+  pump_sub_075kw: 250.0,             // submersible 0.75 kW (up to 60 m)
+  pump_sub_15kw: 380.0,              // submersible 1.5 kW  (up to 100 m)
+  pump_hand_afridev: 320.0,          // Afridev hand pump
+
+  // ── Solar Pump Kits (pump + panels + controller + frame) ─────────────────
+  // Depth matrix (TSG Projects): 0.75HP→50m, 1HP→100m, 1.5HP→100m+, 2HP→120m, 3HP→160m
+  solar_kit_05hp: 1500.0,            // ≤ 30 m depth
+  solar_kit_075hp: 1600.0,           // 30–50 m
+  solar_kit_1hp: 1700.0,             // 50–100 m
+  solar_kit_15hp: 2100.0,            // 80–100 m (high yield)
+  solar_kit_2hp: 2800.0,             // 100–120 m
+  solar_kit_3hp: 3500.0,             // 120–160 m (deep / commercial)
+
+  // ── Hybrid Pump Kits (AC/DC VSD — auto-switches between solar & grid) ────
+  hybrid_kit_1hp: 1850.0,            // 1HP hybrid AC/DC VSD (Nakiso)
+  hybrid_kit_15hp: 2400.0,           // 1.5HP hybrid (estimated)
+  hybrid_kit_2hp: 3200.0,            // 2HP hybrid (estimated)
+
+  // ── Electric Pump Packages ────────────────────────────────────────────────
+  electric_kit_075hp: 750.0,         // 0.75 HP submersible + cable (≤50m)
+  electric_kit_1hp: 950.0,           // 1 HP submersible + cable (50–100m)
+  electric_kit_2hp: 1400.0,          // 2 HP submersible + cable (100–120m)
+  electric_kit_3hp: 1800.0,          // 3 HP submersible + cable (120m+)
+
+  // ── Rising Main (per metre) ───────────────────────────────────────────────
+  rising_hdpe_25mm: 2.8,             // domestic
+  rising_hdpe_32mm: 3.5,             // farm / commercial
+
+  // ── Pump Cable (per metre) ────────────────────────────────────────────────
+  cable_3core_25mm: 1.6,             // 2.5 mm² — shallow
+  cable_3core_40mm: 2.4,             // 4.0 mm² — deep (> 50 m)
+
+  // ── Storage Tanks ─────────────────────────────────────────────────────────
+  tank_2000L: 300.0,
+  tank_2500L: 400.0,
+  tank_5000L: 700.0,
+  tank_10000L: 1200.0,
+  // Steel stands (fixed height)
+  tank_stand_4m: 500.0,              // 4 m elevated steel stand
+  tank_stand_5m: 750.0,              // 5 m elevated steel stand
+  // Per-metre stand pricing for custom heights
+  tank_stand_per_m: 125.0,           // ~$125/m for custom stand height
+
+  // ── Tank + Stand Combos (bundled packages — industry standard pricing) ────
+  combo_5000L_4m: 1000.0,            // DrillCorp, Mutare, Sona Solar
+  combo_5000L_3m: 1100.0,            // Nakiso
+  combo_10000L_4m: 2500.0,           // Nakiso
+
+  // ── Site Security ─────────────────────────────────────────────────────────
+  antitheft_brackets: 1.0,           // per bracket (Sona Solar) — solar panel securing
+  security_cage_estimate: 350.0,     // custom cage for pump/inverter/battery protection
+
+  // ── Site Survey ───────────────────────────────────────────────────────────
+  site_survey_urban: 70.0,
+  site_survey_peri_urban: 120.0,
+  site_survey_rural: 200.0,
+
+  // ── Post-Drilling Services ────────────────────────────────────────────────
+  borehole_flushing: 250.0,
+  yield_test: 250.0,
+  pump_retrieval: 200.0,
+  water_test_bacteriological: 25.0,
+  water_test_chemical: 55.0,
+  purification_system: 450.0,
+
+  // ── Labour ────────────────────────────────────────────────────────────────
+  pump_installation: 150.0,
+
+  // ── Permits & Compliance ──────────────────────────────────────────────────
+  zinwa_permit_gw1: 60.0,
+  council_fee_average: 50.0,
+
+  // ── Mobilization ──────────────────────────────────────────────────────────
+  mobilization_base: 250.0,          // within free radius of depot
+  mobilization_free_radius_km: 20,   // free radius (Nakiso=30km, Gokwe=50km, avg=20km)
+  mobilization_per_km: 3.0,          // per km beyond free radius (avg $2.50–$3.00)
+} as const;
+
+// ── Location metadata ───────────────────────────────────────────────────────
+
+export const LOCATION_DEFAULTS: Record<string, { depth: number; councilFee: number }> = {
+  harare:      { depth: 50,  councilFee: 50 },
+  bulawayo:    { depth: 65,  councilFee: 44 },
+  chitungwiza: { depth: 45,  councilFee: 50 },
+  mutare:      { depth: 50,  councilFee: 50 },
+  gweru:       { depth: 60,  councilFee: 50 },
+  masvingo:    { depth: 55,  councilFee: 360 },
+  kwekwe:      { depth: 55,  councilFee: 50 },
+  kadoma:      { depth: 55,  councilFee: 50 },
+  chinhoyi:    { depth: 50,  councilFee: 50 },
+  marondera:   { depth: 50,  councilFee: 50 },
+  other:       { depth: 60,  councilFee: 50 },
 };

--- a/src/lib/quick-projects/borehole/flow.ts
+++ b/src/lib/quick-projects/borehole/flow.ts
@@ -1,46 +1,667 @@
-import type { QuestionFlow } from '../engine/types';
+import type { QuestionFlow, Answers } from '../engine/types';
 import { calculateBoreholeBOQ } from './calculations';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Check whether the user selected a specific work item for existing borehole. */
+function needsWork(a: Answers, work: string): boolean {
+  const w = a.existing_work_needed;
+  return Array.isArray(w) && w.includes(work);
+}
+
+/** True when the project is a brand-new borehole. */
+function isNew(a: Answers): boolean {
+  return a.project_scope !== 'existing_borehole' && a.project_scope !== 'quick_service';
+}
+
+/** True when the user only needs a quick service (no drilling). */
+function isQuickService(a: Answers): boolean {
+  return a.project_scope === 'quick_service';
+}
+
+/** True when budget mode is selected. */
+function isBudgetMode(a: Answers): boolean {
+  return a.estimate_mode === 'budget';
+}
+
+// ─── Flow ────────────────────────────────────────────────────────────────────
 
 export const boreholeFlow: QuestionFlow = {
   projectType: 'borehole',
   title: 'Borehole Drilling',
-  description: 'Get a full drilling, casing, and pump installation BOQ.',
+  description:
+    'Get a guided estimate for drilling, casing, pump, and water system — or price up work on an existing borehole.',
   icon: 'CirclesThree',
-  estimatedMinutes: 4,
+  estimatedMinutes: 5,
   steps: [
+    // ═══════════════════════════════════════════════════════════════════════
+    // Step 1 — Estimate Mode
+    // ═══════════════════════════════════════════════════════════════════════
     {
-      id: 'depth',
-      title: 'Drilling Depth',
+      id: 'estimate_mode',
+      title: 'How would you like to estimate?',
+      subtitle:
+        'Choose quick for a fast estimate with smart defaults, detailed for full control, or budget to see what fits your budget.',
       questions: [
+        {
+          id: 'estimate_mode',
+          type: 'select',
+          title: 'Estimate type',
+          required: true,
+          options: [
+            {
+              value: 'quick',
+              label: 'Quick Estimate',
+              description:
+                'Answer a few basic questions — we handle the rest with smart defaults. Best if you\'re exploring costs.',
+            },
+            {
+              value: 'detailed',
+              label: 'Detailed Estimate',
+              description:
+                'Choose every specification — casing grade, pump type, services, and compliance. Best for planning a real project.',
+            },
+            {
+              value: 'budget',
+              label: 'Budget Explorer',
+              description:
+                'Enter your budget and see the best borehole package that fits — tank, pump, stand, casing, and depth.',
+            },
+          ],
+        },
+      ],
+    },
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Step 2 — Budget Input (budget mode only)
+    // ═══════════════════════════════════════════════════════════════════════
+    {
+      id: 'budget_input',
+      title: 'What\'s Your Budget?',
+      subtitle:
+        'Enter the total amount you\'d like to spend. We\'ll show you the best combination of drilling depth, casing, pump, and tank that fits.',
+      condition: (a) => isBudgetMode(a),
+      questions: [
+        {
+          id: 'budget_amount',
+          type: 'number',
+          title: 'Total budget',
+          description: 'The maximum amount you want to spend on the full borehole project.',
+          unit: 'USD',
+          min: 500,
+          max: 50000,
+          step: 100,
+          required: true,
+        },
+        {
+          id: 'borehole_purpose',
+          type: 'select',
+          title: 'What is this borehole for?',
+          required: true,
+          options: [
+            {
+              value: 'domestic',
+              label: 'Home use',
+              description: 'Household water supply — drinking, cooking, cleaning, and garden.',
+            },
+            {
+              value: 'agricultural',
+              label: 'Farming & irrigation',
+              description: 'Watering crops, livestock, or large-scale garden irrigation.',
+            },
+            {
+              value: 'commercial',
+              label: 'Business or community',
+              description: 'Schools, lodges, factories, churches, or commercial properties.',
+            },
+          ],
+        },
+        {
+          id: 'project_location',
+          type: 'select',
+          layout: 'dropdown',
+          title: 'Where is the project?',
+          required: true,
+          options: [
+            { value: 'harare', label: 'Harare' },
+            { value: 'bulawayo', label: 'Bulawayo' },
+            { value: 'chitungwiza', label: 'Chitungwiza' },
+            { value: 'mutare', label: 'Mutare' },
+            { value: 'gweru', label: 'Gweru' },
+            { value: 'masvingo', label: 'Masvingo' },
+            { value: 'kwekwe', label: 'Kwekwe' },
+            { value: 'kadoma', label: 'Kadoma' },
+            { value: 'chinhoyi', label: 'Chinhoyi' },
+            { value: 'marondera', label: 'Marondera' },
+            { value: 'other', label: 'Other / not listed' },
+          ],
+        },
+        {
+          id: 'area_type',
+          type: 'select',
+          title: 'What type of area is the site?',
+          required: true,
+          options: [
+            {
+              value: 'urban',
+              label: 'Urban',
+              description: 'City or town centre with good road access.',
+            },
+            {
+              value: 'peri_urban',
+              label: 'Peri-urban',
+              description: 'On the outskirts of town — mostly accessible.',
+            },
+            {
+              value: 'rural',
+              label: 'Rural',
+              description: 'Countryside or farmland — may need off-road transport.',
+            },
+          ],
+        },
+        {
+          id: 'budget_depth',
+          type: 'number',
+          layout: 'slider',
+          title: 'Preferred drilling depth',
+          description: 'Most boreholes in Zimbabwe are 40 m. Slide to adjust — we\'ll fit everything within your budget.',
+          unit: 'm',
+          min: 20,
+          max: 160,
+          step: 5,
+          defaultValue: 40,
+          required: true,
+          recommendation: (a) => {
+            const depth = parseInt(a.budget_depth as string) || 40;
+            if (depth < 40)
+              return '⚠️ Drilling less than 40 m is risky — you may not reach a reliable water source. Most contractors include 40 m in their base package.';
+            if (depth > 100)
+              return 'Very deep boreholes (100 m+) require larger pumps and more casing, which significantly increases cost.';
+            return 'The standard drilling package in Zimbabwe starts at 40 m. This is sufficient for most residential areas.';
+          },
+        },
+      ],
+    },
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Step 3 — Project Basics (non-budget modes)
+    // ═══════════════════════════════════════════════════════════════════════
+    {
+      id: 'project_basics',
+      title: 'About Your Project',
+      subtitle:
+        'Let\'s start with the basics so we can tailor costs, recommendations, and compliance to your needs.',
+      condition: (a) => !isBudgetMode(a),
+      questions: [
+        {
+          id: 'project_name',
+          type: 'text',
+          title: 'Project name',
+          placeholder: 'e.g. "My Home Borehole" or "Farm Well — Plot 12"',
+          required: true,
+        },
+        // ── New or existing? ──────────────────────────────────────────────
+        {
+          id: 'project_scope',
+          type: 'select',
+          title: 'What kind of work do you need?',
+          required: true,
+          options: [
+            {
+              value: 'new_borehole',
+              label: 'New borehole',
+              description: 'Start from scratch — drilling, casing, pump, and everything else.',
+            },
+            {
+              value: 'existing_borehole',
+              label: 'Work on an existing borehole',
+              description:
+                'Additional drilling, casing replacement, pump upgrade, or maintenance on a borehole you already have.',
+            },
+            {
+              value: 'quick_service',
+              label: 'Quick service only',
+              description:
+                'Borehole flushing, water testing, pump retrieval, or other servicing — no drilling or casing work.',
+            },
+          ],
+        },
+        // ── Quick service selection ─────────────────────────────────────
+        {
+          id: 'quick_service_type',
+          type: 'multi-select',
+          title: 'What services do you need?',
+          description: 'Select all that apply.',
+          condition: (a) => isQuickService(a),
+          required: true,
+          options: [
+            {
+              value: 'flushing',
+              label: 'Borehole flushing',
+              description: 'Clear out mud, sand, and debris for clean water flow.',
+            },
+            {
+              value: 'yield_test',
+              label: 'Water yield test',
+              description: 'Measure how much water your borehole produces per hour.',
+            },
+            {
+              value: 'water_test_basic',
+              label: 'Water quality test (bacteria)',
+              description: 'Check for harmful bacteria — recommended for drinking water.',
+            },
+            {
+              value: 'water_test_full',
+              label: 'Full water analysis',
+              description: 'Bacteria + chemical analysis — required for commercial use.',
+            },
+            {
+              value: 'pump_retrieval',
+              label: 'Pump retrieval',
+              description: 'Professional removal of a stuck or dropped pump.',
+            },
+            {
+              value: 'purification',
+              label: 'Water purification system',
+              description: 'Install a basic purification unit for safe drinking water.',
+            },
+          ],
+        },
+        // ── What work is needed? (existing only) ─────────────────────────
+        {
+          id: 'existing_work_needed',
+          type: 'multi-select',
+          title: 'What work do you need done?',
+          description: 'Select all that apply — we\'ll build a combined estimate.',
+          condition: (a) => a.project_scope === 'existing_borehole',
+          required: true,
+          options: [
+            {
+              value: 'additional_drilling',
+              label: 'Deepen the borehole',
+              description: 'Drill additional metres to reach deeper water.',
+            },
+            {
+              value: 'casing_replacement',
+              label: 'Replace or repair casing',
+              description: 'Remove old casing and install new casing.',
+            },
+            {
+              value: 'pump_replacement',
+              label: 'Replace or upgrade pump',
+              description: 'Swap out an old, broken, or undersized pump.',
+            },
+            {
+              value: 'tank_addition',
+              label: 'Add or replace water tank',
+              description: 'Install a new tank and stand, or replace an existing one.',
+            },
+            {
+              value: 'pump_retrieval',
+              label: 'Retrieve a stuck pump',
+              description: 'Professional removal of a jammed or dropped pump from the borehole.',
+            },
+            {
+              value: 'maintenance',
+              label: 'Testing & maintenance',
+              description: 'Flushing, water quality testing, yield testing, or general servicing.',
+            },
+          ],
+        },
+        // ── Purpose ──────────────────────────────────────────────────────
+        {
+          id: 'borehole_purpose',
+          type: 'select',
+          title: 'What is this borehole for?',
+          required: true,
+          options: [
+            {
+              value: 'domestic',
+              label: 'Home use',
+              description: 'Household water supply — drinking, cooking, cleaning, and garden.',
+            },
+            {
+              value: 'agricultural',
+              label: 'Farming & irrigation',
+              description: 'Watering crops, livestock, or large-scale garden irrigation.',
+            },
+            {
+              value: 'commercial',
+              label: 'Business or community',
+              description: 'Schools, lodges, factories, churches, or commercial properties.',
+            },
+          ],
+        },
+        // ── Location ─────────────────────────────────────────────────────
+        {
+          id: 'project_location',
+          type: 'select',
+          layout: 'dropdown',
+          title: 'Where is the project?',
+          required: true,
+          options: [
+            { value: 'harare', label: 'Harare' },
+            { value: 'bulawayo', label: 'Bulawayo' },
+            { value: 'chitungwiza', label: 'Chitungwiza' },
+            { value: 'mutare', label: 'Mutare' },
+            { value: 'gweru', label: 'Gweru' },
+            { value: 'masvingo', label: 'Masvingo' },
+            { value: 'kwekwe', label: 'Kwekwe' },
+            { value: 'kadoma', label: 'Kadoma' },
+            { value: 'chinhoyi', label: 'Chinhoyi' },
+            { value: 'marondera', label: 'Marondera' },
+            { value: 'other', label: 'Other / not listed' },
+          ],
+          recommendation: () =>
+            'Your location affects transport costs, drilling depth estimates, and council permit fees.',
+        },
+        // ── Area type ────────────────────────────────────────────────────
+        {
+          id: 'area_type',
+          type: 'select',
+          title: 'What type of area is the site?',
+          required: true,
+          options: [
+            {
+              value: 'urban',
+              label: 'Urban',
+              description: 'City or town centre with good road access.',
+            },
+            {
+              value: 'peri_urban',
+              label: 'Peri-urban',
+              description: 'On the outskirts of town — mostly accessible.',
+            },
+            {
+              value: 'rural',
+              label: 'Rural',
+              description: 'Countryside or farmland — may need off-road transport.',
+            },
+          ],
+        },
+      ],
+    },
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Step 4 — Site Conditions  (new + detailed only)
+    // ═══════════════════════════════════════════════════════════════════════
+    {
+      id: 'site_conditions',
+      title: 'Your Site',
+      subtitle:
+        'Understanding your ground and survey status helps us recommend the right equipment and flag extra costs. We\'ll cover permits in a later step.',
+      condition: (a) => !isBudgetMode(a) && isNew(a) && !isQuickService(a) && a.estimate_mode === 'detailed',
+      questions: [
+        {
+          id: 'site_survey_done',
+          type: 'select',
+          title: 'Has a professional site survey been done?',
+          description:
+            'A site survey locates the best drilling spot and checks for underground hazards like pipes, cables, or septic tanks.',
+          required: true,
+          options: [
+            {
+              value: 'yes',
+              label: 'Yes, survey completed',
+              description: 'A professional has already identified the drilling point.',
+            },
+            {
+              value: 'no',
+              label: 'Not yet',
+              description: 'We\'ll include a site survey cost in your estimate.',
+              recommended: true,
+            },
+            {
+              value: 'not_sure',
+              label: 'Not sure',
+              description: 'We\'ll recommend including one — you can remove it later.',
+            },
+          ],
+        },
+        {
+          id: 'ground_conditions',
+          type: 'select',
+          title: 'What are the ground conditions?',
+          description:
+            'This affects drilling difficulty and whether extra protection is needed for the borehole walls.',
+          required: true,
+          options: [
+            {
+              value: 'not_sure',
+              label: 'Not sure',
+              description: 'We\'ll use conservative estimates to protect your budget.',
+            },
+            {
+              value: 'rocky',
+              label: 'Rocky or hard ground',
+              description: 'Solid rock — standard drilling, stable borehole walls.',
+            },
+            {
+              value: 'mixed',
+              label: 'Mixed soil and rock',
+              description: 'Combination of soil layers — most common in Zimbabwe.',
+            },
+            {
+              value: 'sandy',
+              label: 'Sandy or loose soil',
+              description:
+                'Unstable ground — may need special drilling fluid or extra casing.',
+            },
+          ],
+          recommendation: (a) => {
+            if (a.ground_conditions === 'sandy')
+              return 'Sandy soil usually requires mud drilling or double casing, which adds to the cost. We\'ll include these automatically. Important: your borehole must be at least 30 metres from any toilet pit, septic tank, or animal pen to prevent contamination.';
+            if (a.ground_conditions === 'rocky' || a.ground_conditions === 'mixed')
+              return 'Make sure the drilling site is at least 30 metres away from septic tanks, toilet pits, graveyards, or animal pens to protect your water quality.';
+            return null;
+          },
+        },
+        {
+          id: 'has_permits',
+          type: 'select',
+          title: 'Do you have the required drilling permits?',
+          description:
+            'In Zimbabwe, you need a ZINWA permit (Form GW1) and local council approval before drilling. Drilling without permits can result in a $150 fine per visit.',
+          required: true,
+          options: [
+            {
+              value: 'no',
+              label: 'No, not yet',
+              description: 'We\'ll include permit costs in your estimate.',
+            },
+            {
+              value: 'yes',
+              label: 'Yes, permits sorted',
+              description: 'We\'ll skip permit costs in your estimate.',
+            },
+            {
+              value: 'not_sure',
+              label: 'Not sure',
+              description: 'We\'ll include them just in case — you can remove them later.',
+            },
+          ],
+          recommendation: () =>
+            'To apply you\'ll need: a site survey report, proof of land ownership (title deed or utility bill), a national ID, and the ZINWA application fee (~$60).',
+        },
+        // ── Site distance (optional for mobilization calc) ──────────────
+        {
+          id: 'site_distance_km',
+          type: 'number',
+          title: 'How far is the site from the nearest town?',
+          description:
+            'Helps calculate transport costs accurately. Leave empty or use "Not sure" for an automatic estimate based on your area type.',
+          unit: 'km',
+          min: 0,
+          max: 500,
+          notSureOption: true,
+          notSureFollowUp: [
+            {
+              id: 'site_distance_km',
+              type: 'number',
+              title: 'We\'ll estimate based on your area type',
+              unit: 'km',
+              defaultValue: 0,
+            },
+          ],
+        },
+      ],
+    },
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Step 5 — Drilling Depth
+    //   New borehole  → full depth
+    //   Existing      → additional metres  (only if selected)
+    // ═══════════════════════════════════════════════════════════════════════
+    {
+      id: 'drilling',
+      title: 'Drilling Depth',
+      subtitle:
+        'The depth of your borehole is the biggest factor in cost. Don\'t worry if you\'re not sure — we\'ll estimate based on your area.',
+      condition: (a) => !isBudgetMode(a) && !isQuickService(a) && (isNew(a) || needsWork(a, 'additional_drilling')),
+      questions: [
+        // ── New borehole: full depth ─────────────────────────────────────
         {
           id: 'drilling_depth',
           type: 'number',
           title: 'Expected drilling depth',
           unit: 'm',
-          min: 10, max: 200,
-          defaultValue: 60,
+          min: 10,
+          max: 200,
           required: true,
+          condition: (a) => isNew(a),
           notSureOption: true,
           notSureFollowUp: [
-            { id: 'drilling_depth', type: 'number', title: 'We estimate 60m for most Zimbabwe properties', unit: 'm', defaultValue: 60 },
+            {
+              id: 'drilling_depth',
+              type: 'number',
+              title: 'Estimated depth for your area (you can adjust this)',
+              unit: 'm',
+              defaultValue: 50,
+            },
           ],
-          recommendation: () => 'Typical Zimbabwe depth: 40–80m. Urban Harare ~40–60m. Rural areas can exceed 100m.',
+          recommendation: (a) => {
+            const loc = a.project_location as string;
+            const area = a.area_type as string;
+            const tips: Record<string, string> = {
+              harare: 'Harare typically needs 40\u201360 m.',
+              bulawayo: 'Bulawayo usually requires 50\u201380 m.',
+              chitungwiza: 'Chitungwiza is similar to Harare \u2014 40\u201360 m.',
+              mutare: 'Mutare area typically needs 40\u201360 m.',
+              gweru: 'Gweru area usually requires 50\u201370 m.',
+              masvingo: 'Masvingo area typically needs 50\u201370 m.',
+            };
+            let tip = tips[loc] || 'Most Zimbabwe properties need 40\u201380 m depth.';
+            if (area === 'rural') tip += ' Rural areas can sometimes exceed 100 m.';
+            tip += ' Note: final depth depends on the hydrogeologist\u2019s report and actual ground conditions.';
+            return tip;
+          },
+        },
+        // ── Existing borehole: additional metres ─────────────────────────
+        {
+          id: 'additional_metres',
+          type: 'number',
+          title: 'How many additional metres do you need drilled?',
+          description:
+            'This is the extra depth beyond the current borehole. Mobilization costs will be included automatically.',
+          unit: 'm',
+          min: 5,
+          max: 100,
+          defaultValue: 20,
+          required: true,
+          condition: (a) => !isNew(a) && needsWork(a, 'additional_drilling'),
+          recommendation: () =>
+            'Typical deepening is 10\u201330 m. Your driller can advise on the exact depth once they inspect the existing borehole.',
         },
       ],
     },
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Step 6 — Casing
+    //   New + detailed → full casing spec
+    //   Existing + casing_replacement → replacement spec
+    // ═══════════════════════════════════════════════════════════════════════
     {
       id: 'casing',
       title: 'Casing',
+      subtitle:
+        'Casing lines the inside of your borehole to prevent collapse and keep the water clean. The top 10\u201320 metres are critical for sealing out surface contamination.',
+      condition: (a) =>
+        !isBudgetMode(a) &&
+        !isQuickService(a) &&
+        ((isNew(a) && a.estimate_mode === 'detailed') ||
+        (a.project_scope === 'existing_borehole' && needsWork(a, 'casing_replacement'))),
       questions: [
+        // ── Length to replace (existing only) ─────────────────────────────
         {
-          id: 'casing_type',
+          id: 'casing_replacement_length',
+          type: 'number',
+          title: 'Length of casing to replace',
+          description:
+            'How many metres of casing need replacing? Enter the full depth if doing a complete swap.',
+          unit: 'm',
+          min: 5,
+          max: 200,
+          defaultValue: 40,
+          required: true,
+          condition: (a) => !isNew(a) && needsWork(a, 'casing_replacement'),
+        },
+        {
+          id: 'casing_material',
           type: 'select',
           title: 'Casing material',
           required: true,
           options: [
-            { value: 'upvc',  label: 'uPVC casing',   description: 'Most common. Corrosion-resistant and cost-effective.', recommended: true },
-            { value: 'steel', label: 'Steel casing',  description: 'More durable in deep boreholes (>80m).' },
+            {
+              value: 'upvc',
+              label: 'PVC casing',
+              description:
+                'Most popular — lightweight, corrosion-resistant, and cost-effective.',
+              recommended: true,
+            },
+            {
+              value: 'steel',
+              label: 'Steel casing',
+              description:
+                'Stronger but heavier and more expensive. Best for very deep (>80 m) or rocky boreholes.',
+            },
           ],
+        },
+        {
+          id: 'casing_class',
+          type: 'select',
+          title: 'Casing grade',
+          condition: (a) => a.casing_material === 'upvc',
+          required: true,
+          options: [
+            {
+              value: 'class_6',
+              label: 'Standard (Class 6)',
+              description: 'Suitable for most residential boreholes in stable soil. Pressure rating: 6 Bar.',
+              recommended: true,
+            },
+            {
+              value: 'class_9',
+              label: 'Mid-grade (Class 9)',
+              description:
+                'Good balance of durability and cost — suitable for moderate depths and mixed soil. Pressure rating: 9 Bar.',
+            },
+            {
+              value: 'class_10',
+              label: 'Premium (Class 10)',
+              description:
+                'Highest pressure rating (10 Bar) — recommended for deep boreholes (>60 m) or rocky terrain.',
+            },
+          ],
+          recommendation: (a) => {
+            const depth =
+              parseInt(a.drilling_depth as string) ||
+              parseInt(a.casing_replacement_length as string) ||
+              50;
+            const ground = a.ground_conditions as string;
+            if (depth > 60 || ground === 'rocky')
+              return 'For depths over 60 m or rocky ground, we recommend Class 9 or Class 10 casing for better durability and pressure resistance.';
+            return null;
+          },
         },
         {
           id: 'casing_diameter',
@@ -48,62 +669,425 @@ export const boreholeFlow: QuestionFlow = {
           title: 'Casing diameter',
           required: true,
           options: [
-            { value: '100mm', label: '100mm', description: 'Standard domestic borehole.', recommended: true },
-            { value: '150mm', label: '150mm', description: 'Higher yield — commercial / farm use.' },
+            {
+              value: '140mm',
+              label: '140 mm',
+              description: 'Standard size for home use — fits most domestic pumps.',
+            },
+            {
+              value: '180mm',
+              label: '180 mm',
+              description: 'Wider bore — higher water yield for farming or commercial use.',
+            },
           ],
+          recommendation: (a) => {
+            const purpose = a.borehole_purpose as string;
+            if (purpose === 'agricultural' || purpose === 'commercial')
+              return 'For farming or commercial use, 180 mm provides higher water yield.';
+            return '140 mm is usually sufficient and more cost-effective for home use.';
+          },
+        },
+        {
+          id: 'double_casing',
+          type: 'toggle',
+          title: 'Add double casing for the top section',
+          description:
+            'Adds an extra layer of protection for the top 6\u201320 metres. Recommended for sandy or loose soil.',
+          defaultValue: false,
+          condition: (a) =>
+            isNew(a) &&
+            (a.ground_conditions === 'sandy' || a.ground_conditions === 'mixed'),
+          recommendation: (a) => {
+            if (a.ground_conditions === 'sandy')
+              return 'Your site has sandy soil — double casing is strongly recommended to prevent collapse. The top section should be widened to 300mm for a proper sanitary seal.';
+            return null;
+          },
         },
       ],
     },
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Step 7 — Water System
+    //   New                          → full system choice
+    //   Existing + pump/tank work    → pump or tank selection
+    // ═══════════════════════════════════════════════════════════════════════
     {
-      id: 'pump',
-      title: 'Pump',
+      id: 'water_system',
+      title: 'Your Water System',
+      subtitle:
+        'Tell us what you need — just the borehole, or a complete system with pump, tank, and stand.',
+      condition: (a) =>
+        !isBudgetMode(a) &&
+        !isQuickService(a) &&
+        (isNew(a) ||
+        needsWork(a, 'pump_replacement') ||
+        needsWork(a, 'tank_addition')),
       questions: [
+        // ── System scope (new only) ──────────────────────────────────────
         {
-          id: 'pump_type',
+          id: 'system_scope',
           type: 'select',
-          title: 'Pump type',
+          title: 'What do you need?',
+          required: true,
+          condition: (a) => isNew(a),
+          options: [
+            {
+              value: 'drilling_only',
+              label: 'Borehole drilling only',
+              description:
+                'Just the hole and casing — I\'ll sort the pump and tank separately.',
+            },
+            {
+              value: 'drilling_and_pump',
+              label: 'Borehole + pump',
+              description:
+                'Drilling plus a pump to extract water. I already have a tank or don\'t need one yet.',
+            },
+            {
+              value: 'complete_system',
+              label: 'Complete system',
+              description:
+                'Everything — drilling, pump, water tank, and stand. Ready to use.',
+              recommended: true,
+            },
+          ],
+        },
+
+        // ── Existing borehole depth (needed for pump sizing) ─────────────
+        {
+          id: 'existing_borehole_depth',
+          type: 'number',
+          title: 'What is the current depth of your borehole?',
+          description: 'This helps us recommend the right pump size. An estimate is fine.',
+          unit: 'm',
+          min: 10,
+          max: 200,
+          defaultValue: 50,
+          required: true,
+          condition: (a) => !isNew(a) && needsWork(a, 'pump_replacement'),
+        },
+
+        // ── Pump power source ────────────────────────────────────────────
+        {
+          id: 'pump_power_source',
+          type: 'select',
+          title: 'How do you want to power the pump?',
+          condition: (a) => {
+            if (!isNew(a)) return needsWork(a, 'pump_replacement');
+            return a.system_scope !== 'drilling_only';
+          },
           required: true,
           options: [
-            { value: 'submersible', label: 'Submersible pump',  description: 'Electric pump inside borehole. Most efficient.', recommended: true },
-            { value: 'hand',        label: 'Afridev hand pump', description: 'Manual operation. No electricity required.' },
-            { value: 'none',        label: 'Drilling only',     description: 'No pump — I will source it separately.' },
+            {
+              value: 'solar',
+              label: 'Solar powered',
+              description:
+                'No electricity bills, works during load shedding. Includes panels, controller, and pump.',
+              recommended: true,
+            },
+            {
+              value: 'hybrid',
+              label: 'Hybrid (Solar + Grid)',
+              description:
+                'Automatically switches between solar and ZESA grid power. Best of both worlds — higher upfront cost but maximum reliability.',
+            },
+            {
+              value: 'electric',
+              label: 'Electric (ZESA grid)',
+              description:
+                'Lower upfront cost but depends on grid power and has ongoing electricity bills.',
+            },
+            {
+              value: 'hand',
+              label: 'Hand pump (Afridev)',
+              description:
+                'Manual operation — no electricity needed. Common in rural areas and community boreholes.',
+            },
           ],
+          recommendation: (a) => {
+            const purpose = a.borehole_purpose as string;
+            if (purpose === 'commercial')
+              return 'For commercial use, hybrid (AC/DC) systems provide maximum uptime — solar during the day, grid power at night or on cloudy days.';
+            return 'Solar is the most popular choice in Zimbabwe — it eliminates electricity costs and works during power outages. Solar array should be 1.3\u20131.5\u00D7 the pump wattage for best performance.';
+          },
+        },
+
+        // ── Tank capacity ────────────────────────────────────────────────
+        {
+          id: 'tank_capacity',
+          type: 'select',
+          title: 'Water storage tank size',
+          condition: (a) => {
+            if (!isNew(a)) return needsWork(a, 'tank_addition');
+            return a.system_scope === 'complete_system';
+          },
+          required: true,
+          options: [
+            {
+              value: '2000',
+              label: '2,000 litres',
+              description: 'Compact — suitable for a very small household (1\u20132 people).',
+            },
+            {
+              value: '2500',
+              label: '2,500 litres',
+              description: 'Good for a small household (2\u20134 people).',
+            },
+            {
+              value: '5000',
+              label: '5,000 litres',
+              description: 'Suitable for a medium household or small garden.',
+              recommended: true,
+            },
+            {
+              value: '10000',
+              label: '10,000 litres',
+              description: 'Best for large households, farming, or commercial use.',
+            },
+          ],
+          recommendation: (a) => {
+            const purpose = a.borehole_purpose as string;
+            if (purpose === 'agricultural')
+              return 'For farming, we recommend at least 5,000 L. Consider 10,000 L if irrigating crops.';
+            if (purpose === 'commercial')
+              return 'For commercial use, 10,000 L provides the best buffer for continuous supply.';
+            return 'For a typical household, 5,000 L covers daily needs with some reserve.';
+          },
+        },
+
+        // ── Tank stand ───────────────────────────────────────────────────
+        {
+          id: 'include_tank_stand',
+          type: 'select',
+          title: 'Do you need a steel tank stand?',
+          description:
+            'An elevated stand provides gravity-fed water pressure to your building.',
+          condition: (a) => {
+            if (!isNew(a)) return needsWork(a, 'tank_addition');
+            return a.system_scope === 'complete_system';
+          },
+          required: true,
+          options: [
+            {
+              value: 'combo',
+              label: 'Yes \u2014 bundled with tank (saves ~$200)',
+              description: 'Tank + stand package deal at discounted rate. Most popular with contractors.',
+              recommended: true,
+            },
+            {
+              value: 'standard',
+              label: 'Yes \u2014 standard height (separate)',
+              description: '4 m for most tanks, 5 m for 10,000 L. Priced separately.',
+            },
+            {
+              value: 'custom',
+              label: 'Yes \u2014 custom height',
+              description: 'I know the exact height I need.',
+            },
+            {
+              value: 'no',
+              label: 'No stand needed',
+              description: 'I\u2019ll place the tank on the ground or have my own stand.',
+            },
+          ],
+        },
+        {
+          id: 'tank_stand_height',
+          type: 'number',
+          title: 'Stand height',
+          description: 'Standard is 4\u20135 m. Taller stands give more water pressure.',
+          unit: 'm',
+          min: 2,
+          max: 10,
+          defaultValue: 4,
+          required: true,
+          condition: (a) => a.include_tank_stand === 'custom',
         },
       ],
     },
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Step 8 — Site Security (detailed mode, new + solar/hybrid)
+    // ═══════════════════════════════════════════════════════════════════════
     {
-      id: 'rising_main',
-      title: 'Rising Main',
-      condition: (a) => a.pump_type !== 'none',
+      id: 'site_security',
+      title: 'Site Security',
+      subtitle:
+        'Protect your investment. Equipment theft is a common concern — these add-ons help secure your borehole system.',
+      condition: (a) =>
+        !isBudgetMode(a) &&
+        !isQuickService(a) &&
+        a.estimate_mode === 'detailed' &&
+        (isNew(a) || needsWork(a, 'pump_replacement')) &&
+        (a.pump_power_source === 'solar' || a.pump_power_source === 'hybrid'),
       questions: [
         {
-          id: 'rising_material',
-          type: 'select',
-          title: 'Rising main material',
-          options: [
-            { value: 'hdpe',  label: 'HDPE pipe',  description: 'Flexible, most common for boreholes.', recommended: true },
-            { value: 'upvc',  label: 'uPVC pipe',  description: 'Rigid, suitable for shallow boreholes.' },
-          ],
+          id: 'include_antitheft_brackets',
+          type: 'toggle',
+          title: 'Anti-theft brackets for solar panels',
+          description:
+            'Tamper-proof bolts and brackets to secure solar panels to the mounting frame. ~$1 per bracket.',
+          defaultValue: true,
         },
         {
-          id: 'rising_diameter',
-          type: 'select',
-          title: 'Pipe diameter',
-          options: [
-            { value: '25mm', label: '25mm', description: 'Sufficient for most domestic pumps.' },
-            { value: '32mm', label: '32mm', description: 'Higher flow rate — farm or commercial.', recommended: true },
-          ],
+          id: 'antitheft_bracket_qty',
+          type: 'number',
+          title: 'Number of brackets needed',
+          description: 'Typically 4\u20138 brackets per installation depending on panel count.',
+          unit: 'pcs',
+          min: 1,
+          max: 20,
+          defaultValue: 6,
+          condition: (a) => Boolean(a.include_antitheft_brackets),
+        },
+        {
+          id: 'include_security_cage',
+          type: 'toggle',
+          title: 'Security cage for pump/inverter/battery',
+          description:
+            'A high-strength steel cage custom-fabricated to protect your solar inverter, battery, and pump controller from theft and vandalism.',
+          defaultValue: false,
+        },
+        {
+          id: 'security_cage_cost',
+          type: 'number',
+          title: 'Security cage cost',
+          description: 'Enter the quoted price if you have one, or use our estimate of $350.',
+          unit: 'USD',
+          min: 100,
+          max: 2000,
+          defaultValue: 350,
+          condition: (a) => Boolean(a.include_security_cage),
         },
       ],
     },
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Step 9 — Services & Compliance
+    //   New + detailed                → full service toggles
+    //   Existing + maintenance        → service toggles
+    // ═══════════════════════════════════════════════════════════════════════
     {
-      id: 'optional_costs',
-      title: 'Optional Costs',
+      id: 'services',
+      title: 'Services & Compliance',
+      subtitle:
+        'These ensure your borehole is legal, safe, and fully operational. We recommend including all essentials — you can toggle any off.',
+      condition: (a) =>
+        !isBudgetMode(a) &&
+        !isQuickService(a) &&
+        ((isNew(a) && a.estimate_mode === 'detailed') ||
+        (a.project_scope === 'existing_borehole' && needsWork(a, 'maintenance'))),
       questions: [
-        { id: 'include_mobilization',  type: 'toggle', title: 'Include rig mobilization cost',       defaultValue: true },
-        { id: 'include_pump_test',     type: 'toggle', title: 'Include pump test & development',      defaultValue: true },
-        { id: 'include_water_test',    type: 'toggle', title: 'Include water quality lab test',        defaultValue: false },
-        { id: 'include_pump_install',  type: 'toggle', title: 'Include pump installation labour',     defaultValue: true },
+        {
+          id: 'include_site_survey',
+          type: 'toggle',
+          title: 'Site survey',
+          description:
+            'A professional locates the best drilling spot and checks for underground hazards.',
+          condition: (a) => isNew(a) && a.site_survey_done !== 'yes',
+          defaultValue: true,
+        },
+        {
+          id: 'include_flushing',
+          type: 'toggle',
+          title: 'Borehole flushing',
+          description:
+            'Clears mud, sand, and drilling debris. Essential for clean water after any drilling or maintenance work.',
+          defaultValue: true,
+        },
+        {
+          id: 'include_yield_test',
+          type: 'toggle',
+          title: 'Water yield test',
+          description:
+            'Measures how much water your borehole produces per hour. Helps size your pump correctly.',
+          defaultValue: true,
+          recommendation: () =>
+            'Yield testing is mandatory for ZINWA compliance and helps ensure your pump is correctly sized. Cost: $250 flat fee.',
+        },
+        {
+          id: 'water_quality_level',
+          type: 'select',
+          title: 'Water quality testing',
+          description:
+            'Lab analysis to check if the water is safe for use. Required for commercial properties.',
+          required: true,
+          options: [
+            {
+              value: 'none',
+              label: 'Skip for now',
+              description: 'You can always test the water later.',
+            },
+            {
+              value: 'basic',
+              label: 'Basic (bacteria check) — $25',
+              description: 'Tests for harmful bacteria — recommended for drinking water.',
+            },
+            {
+              value: 'full',
+              label: 'Full analysis — $80',
+              description:
+                'Bacteria ($25) + chemical analysis ($55) — required for commercial use or schools.',
+              recommended: true,
+            },
+          ],
+          recommendation: (a) => {
+            const purpose = a.borehole_purpose as string;
+            if (purpose === 'commercial')
+              return 'Commercial and community boreholes must have full water quality analysis for health certification.';
+            if (purpose === 'domestic')
+              return 'We recommend at least a basic test to confirm the water is safe for your family.';
+            return null;
+          },
+        },
+        {
+          id: 'include_zinwa_permit',
+          type: 'toggle',
+          title: 'ZINWA drilling permit (Form GW1) — $60',
+          description:
+            'Required by law before drilling. This is a non-negotiable requirement for all new boreholes in Zimbabwe.',
+          condition: (a) => isNew(a) && a.has_permits !== 'yes',
+          defaultValue: true,
+          recommendation: () =>
+            'Drilling without a ZINWA permit is illegal and can result in a $150 fine per visit. Penalties for unauthorised drilling can reach up to $2,000.',
+        },
+        {
+          id: 'include_council_fee',
+          type: 'toggle',
+          title: 'Local council approval fee',
+          description: 'Application fee required by your local municipality before drilling.',
+          condition: (a) => isNew(a) && a.has_permits !== 'yes',
+          defaultValue: true,
+        },
+        {
+          id: 'include_mobilization',
+          type: 'toggle',
+          title: 'Drilling rig transport',
+          description:
+            'Cost to bring the drilling rig to your site. Varies by distance from the depot.',
+          condition: (a) => isNew(a),
+          defaultValue: true,
+        },
+        {
+          id: 'include_pump_install',
+          type: 'toggle',
+          title: 'Pump installation labour',
+          description: 'Professional installation of your pump system. Important: the pump must never be placed inside the well screen to avoid erosion damage.',
+          condition: (a) => {
+            if (!isNew(a)) return false; // existing path handles this automatically
+            return a.system_scope !== 'drilling_only';
+          },
+          defaultValue: true,
+        },
+        {
+          id: 'include_purification',
+          type: 'toggle',
+          title: 'Water purification system',
+          description:
+            'Basic purification unit for safe drinking water — recommended for schools, lodges, and businesses.',
+          condition: (a) => a.borehole_purpose === 'commercial',
+          defaultValue: false,
+        },
       ],
     },
   ],

--- a/src/lib/quick-projects/solar/boq.ts
+++ b/src/lib/quick-projects/solar/boq.ts
@@ -1,59 +1,76 @@
 // ─── Solar BOQ Generator ───────────────────────────────────────────────────────
 // Converts SolarSizingResult + wizard answers → BOQItem[]
-// Fills the gap between the existing sizing engine and the new BOQ table.
+// Updated Q1 2026 with Zimbabwe mid-range market pricing.
 
 import { makeItem, type BOQItem } from '../engine/types';
 import type { SolarSizingResult, SolarWizardAnswers } from './types';
+import {
+  INVERTER_BRANDS,
+  BATTERY_BRANDS,
+  PANEL_BRANDS,
+  MAINTENANCE_SERVICES,
+  getRequiredZeraTier,
+} from './catalog';
 
 // ─── Price Catalog ─────────────────────────────────────────────────────────────
-// Prices are per-component; overridden at runtime by Supabase weekly_prices.
+// 2025 Zimbabwe mid-range prices. Overridden at runtime by Supabase weekly_prices.
 
 const SOLAR_PRICES: Record<string, number> = {
-  panel_550w:            110.00,   // each - generic 550W panel
-  panel_ja_550w:         115.00,   // each - JA Solar 550W
-  panel_canadian_550w:   120.00,   // each - Canadian Solar 550W
-  inverter_3kva:         550.00,   // each - 3kVA hybrid
-  inverter_5kva:         900.00,   // each - 5kVA hybrid
-  inverter_8kva:        1350.00,   // each - 8kVA hybrid
-  inverter_10kva:       1700.00,   // each - 10kVA hybrid
-  inverter_12kva:       2100.00,   // each - 12kVA hybrid
-  inverter_deye_5kva:    920.00,
-  inverter_victron_5kva:1450.00,
-  inverter_solarmd_5kva: 880.00,
-  battery_5kwh:          550.00,   // each - generic 5kWh LiFePO4 unit
-  battery_pylontech_5kwh:580.00,
-  battery_freedomwon_5kwh:620.00,
+  // ── Balance of System (Protection Layer) ──────────────────────────────────
   mounting_kit:          120.00,   // set - roof mounting rails + hardware
-  dc_cable_6mm:            2.50,   // m
+  dc_cable_6mm:            2.50,   // m - UV-resistant
   ac_cable_4mm:            1.80,   // m
   combiner_4str:          35.00,   // each - 4-string combiner box
   dc_isolator:            22.00,   // each
   ac_isolator:            18.00,   // each
-  surge_dc:               25.00,   // each - DC surge protection
-  surge_ac:               25.00,   // each - AC surge protection
-  earthing_kit:           45.00,   // set
+  surge_dc:               25.00,   // each - DC surge protection device
+  surge_ac:               25.00,   // each - AC surge protection device
+  avs:                    35.00,   // each - Automatic Voltage Switcher (ZESA protection)
+  battery_breaker:        28.00,   // each - 125A DC breaker for battery
+  changeover_switch:      45.00,   // each - Solar/ZESA/Generator selector
+  distribution_board:     55.00,   // each - 8-way DB board
+  earthing_kit:           45.00,   // set - dedicated solar + AC earthing (<5 ohm)
   cable_trunking_m:        1.20,   // m
+  antitheft_brackets:      8.00,   // set - panel anti-theft bolts
+
+  // ── Installation ──────────────────────────────────────────────────────────
   transport:              80.00,   // trip
-  install_labor_pct:        0.25,  // 25% of hardware cost
+  install_labor_pct:        0.20,  // 20% of hardware cost (was 25%)
 };
 
-function panelPrice(brand: string): number {
-  if (brand === 'ja_solar') return SOLAR_PRICES.panel_ja_550w;
-  if (brand === 'canadian_solar') return SOLAR_PRICES.panel_canadian_550w;
-  return SOLAR_PRICES.panel_550w;
+// ─── Brand Lookup Helpers ──────────────────────────────────────────────────────
+
+function panelPrice(brand: string): { price: number; watt: number; label: string } {
+  const found = PANEL_BRANDS.find((p) => p.brand === brand);
+  if (found) return { price: found.pricePerPanel, watt: found.watt, label: found.label };
+  // Default to JA Solar (best value mid-range)
+  return { price: 56, watt: 440, label: 'JA Solar' };
 }
 
 function inverterPrice(kva: number, brand: string): number {
-  const key = `inverter_${brand === 'deye' ? 'deye' : brand === 'victron' ? 'victron' : brand === 'solarmd' ? 'solarmd' : ''}_${kva}kva`.replace('_kva', 'kva');
-  if (SOLAR_PRICES[key]) return SOLAR_PRICES[key];
-  const generic = `inverter_${kva}kva`;
-  return SOLAR_PRICES[generic] ?? SOLAR_PRICES.inverter_5kva;
+  const found = INVERTER_BRANDS.find((b) => b.brand === brand);
+  if (found) {
+    // Find exact or closest kVA
+    if (found.prices[kva]) return found.prices[kva];
+    const sizes = Object.keys(found.prices).map(Number).sort((a, b) => a - b);
+    const closest = sizes.find((s) => s >= kva) ?? sizes[sizes.length - 1];
+    return found.prices[closest];
+  }
+  // Default mid-range pricing per kVA
+  const defaults: Record<number, number> = { 3: 350, 5: 650, 8: 1000, 10: 1400, 12: 1800 };
+  return defaults[kva] ?? kva * 130;
 }
 
-function batteryUnitPrice(brand: string): number {
-  if (brand === 'pylontech') return SOLAR_PRICES.battery_pylontech_5kwh;
-  if (brand === 'freedom_won') return SOLAR_PRICES.battery_freedomwon_5kwh;
-  return SOLAR_PRICES.battery_5kwh;
+function inverterLabel(brand: string): string {
+  const found = INVERTER_BRANDS.find((b) => b.brand === brand);
+  return found?.label ?? 'Hybrid';
+}
+
+function batteryUnitPrice(brand: string): { price: number; kwh: number; label: string } {
+  const found = BATTERY_BRANDS.find((b) => b.brand === brand);
+  if (found) return { price: found.unitPrice, kwh: found.unitKwh, label: found.label };
+  // Default mid-range
+  return { price: 790, kwh: 5.12, label: 'LiFePO4' };
 }
 
 // ─── Main Converter ────────────────────────────────────────────────────────────
@@ -69,63 +86,112 @@ export function solarSizingToBOQ(
     include_contingency?: boolean;
   }
 ): BOQItem[] {
-  const panelBrand = answers.panel_brand ?? 'generic';
-  const invBrand = answers.inverter_brand ?? 'generic';
-  const batBrand = answers.battery_brand ?? 'generic';
+  const pBrand = answers.panel_brand ?? 'ja_solar';
+  const iBrand = answers.inverter_brand ?? 'must';
+  const bBrand = answers.battery_brand ?? 'dyness';
 
   // Owned items from the existing wizard
   const ownedPanels = answers.existing?.hasExisting && (answers.existing.panelCount ?? 0) >= result.panelCount;
   const ownedInverter = answers.existing?.hasExisting && (answers.existing.inverterKva ?? 0) >= result.inverterKva;
   const ownedBatteries = answers.existing?.hasExisting && (answers.existing.batteryKwh ?? 0) >= result.batteryKwh;
 
-  const batteryUnits = Math.ceil(result.batteryKwh / 5); // each unit is 5kWh
-  const dcCableM = result.panelCount * 4 + 5; // ~4m/panel + 5m spares
+  const panel = panelPrice(pBrand);
+  const battery = batteryUnitPrice(bBrand);
+  const batteryUnits = Math.max(1, Math.ceil(result.batteryKwh / battery.kwh));
+  const dcCableM = result.panelCount * 4 + 5;
   const acCableM = 10;
+  const invPrice = inverterPrice(result.inverterKva, iBrand);
+  const invLabel = inverterLabel(iBrand);
+  const systemWatts = result.solarArrayKw * 1000;
 
   const items: BOQItem[] = [
+    // ── Hardware Layer ────────────────────────────────────────────────────
     makeItem(
       'sol_panels', 'Solar Panels',
-      `Solar panels ${Math.round(result.solarArrayKw * 1000 / result.panelCount)}W${panelBrand !== 'generic' ? ` (${panelBrand.replace('_', ' ')})` : ''}`,
-      result.panelCount, 'each', panelPrice(panelBrand),
-      { owned: ownedPanels }
+      `${panel.watt}W ${panel.label} solar panels`,
+      result.panelCount, 'each', panel.price,
+      { owned: ownedPanels, notes: `${(result.panelCount * panel.watt / 1000).toFixed(1)}kW total array` }
     ),
     makeItem(
       'sol_inverter', 'Inverter',
-      `Hybrid inverter ${result.inverterKva}kVA${invBrand !== 'generic' ? ` (${invBrand.replace('_', ' ')})` : ''}`,
-      1, 'each', inverterPrice(result.inverterKva, invBrand),
+      `${result.inverterKva}kVA ${invLabel} hybrid inverter`,
+      1, 'each', invPrice,
       { owned: ownedInverter }
     ),
     makeItem(
       'sol_batteries', 'Batteries',
-      `LiFePO4 battery 5kWh × ${batteryUnits}${batBrand !== 'generic' ? ` (${batBrand.replace('_', ' ')})` : ''}`,
-      batteryUnits, 'each', batteryUnitPrice(batBrand),
-      { owned: ownedBatteries }
+      `${battery.kwh}kWh ${battery.label} LiFePO4 × ${batteryUnits}`,
+      batteryUnits, 'each', battery.price,
+      { owned: ownedBatteries, notes: `${(batteryUnits * battery.kwh).toFixed(1)}kWh total storage` }
     ),
-    makeItem('sol_mount',    'Balance of System', 'Panel mounting kit (rails + hardware)',  1,         'set',  SOLAR_PRICES.mounting_kit),
-    makeItem('sol_dc_cable', 'Balance of System', 'DC cable 6mm²',                          dcCableM,  'm',    SOLAR_PRICES.dc_cable_6mm),
-    makeItem('sol_ac_cable', 'Balance of System', 'AC cable 4mm²',                          acCableM,  'm',    SOLAR_PRICES.ac_cable_4mm),
-    makeItem('sol_combiner', 'Balance of System', '4-string combiner box',                  1,         'each', SOLAR_PRICES.combiner_4str),
-    makeItem('sol_dc_iso',   'Balance of System', 'DC isolator',                            1,         'each', SOLAR_PRICES.dc_isolator),
-    makeItem('sol_ac_iso',   'Balance of System', 'AC isolator',                            1,         'each', SOLAR_PRICES.ac_isolator),
-    makeItem('sol_surge_dc', 'Balance of System', 'DC surge protection device',             1,         'each', SOLAR_PRICES.surge_dc),
-    makeItem('sol_surge_ac', 'Balance of System', 'AC surge protection device',             1,         'each', SOLAR_PRICES.surge_ac),
-    makeItem('sol_earth',    'Balance of System', 'Earthing kit',                           1,         'set',  SOLAR_PRICES.earthing_kit),
-    makeItem('sol_trunking', 'Balance of System', 'Cable trunking / conduit',               dcCableM + acCableM, 'm', SOLAR_PRICES.cable_trunking_m),
+
+    // ── Protection Layer (critical for system longevity) ──────────────────
+    makeItem('sol_mount',       'Balance of System', 'Panel mounting kit (rails + hardware + anti-theft)',       1,         'set',  SOLAR_PRICES.mounting_kit + SOLAR_PRICES.antitheft_brackets),
+    makeItem('sol_dc_cable',    'Balance of System', 'DC cable 6mm² (UV-resistant)',                            dcCableM,  'm',    SOLAR_PRICES.dc_cable_6mm),
+    makeItem('sol_ac_cable',    'Balance of System', 'AC cable 4mm²',                                          acCableM,  'm',    SOLAR_PRICES.ac_cable_4mm),
+    makeItem('sol_combiner',    'Balance of System', '4-string combiner box',                                   1,         'each', SOLAR_PRICES.combiner_4str),
+    makeItem('sol_dc_iso',      'Protection',        'DC isolator',                                             1,         'each', SOLAR_PRICES.dc_isolator),
+    makeItem('sol_ac_iso',      'Protection',        'AC isolator',                                             1,         'each', SOLAR_PRICES.ac_isolator),
+    makeItem('sol_surge_dc',    'Protection',        'DC surge protection device (SPD)',                         1,         'each', SOLAR_PRICES.surge_dc,
+      { notes: 'Protects against lightning-induced surges on solar lines' }),
+    makeItem('sol_surge_ac',    'Protection',        'AC surge protection device (SPD)',                         1,         'each', SOLAR_PRICES.surge_ac,
+      { notes: 'Shields inverter from grid-side surges' }),
+    makeItem('sol_avs',         'Protection',        'Automatic Voltage Switcher (AVS)',                        1,         'each', SOLAR_PRICES.avs,
+      { notes: 'Disconnects system during ZESA brownouts or over-voltage' }),
+    makeItem('sol_bat_breaker', 'Protection',        'Battery DC breaker (125A)',                               1,         'each', SOLAR_PRICES.battery_breaker),
+    makeItem('sol_changeover',  'Protection',        'Changeover switch (Solar/ZESA/Generator)',                 1,         'each', SOLAR_PRICES.changeover_switch),
+    makeItem('sol_db',          'Protection',        'Distribution board (8-way)',                               1,         'each', SOLAR_PRICES.distribution_board),
+    makeItem('sol_earth',       'Protection',        'Earthing kit (solar + AC, <5Ω)',                          1,         'set',  SOLAR_PRICES.earthing_kit),
+    makeItem('sol_trunking',    'Balance of System', 'Cable trunking / conduit',                                dcCableM + acCableM, 'm', SOLAR_PRICES.cable_trunking_m),
   ];
 
+  // ── Transport ─────────────────────────────────────────────────────────
   if (answers.include_transport) {
     items.push(makeItem('sol_transport', 'Site Work', 'Equipment delivery / transport', 1, 'trip', SOLAR_PRICES.transport, { optional: true }));
   }
 
+  // ── Installation ──────────────────────────────────────────────────────
   if (answers.include_install) {
     const hardware = items.filter((i) => !i.owned).reduce((s, i) => s + i.totalCostUsd, 0);
     const installCost = +(hardware * SOLAR_PRICES.install_labor_pct).toFixed(2);
-    items.push(makeItem('sol_install', 'Labor', 'Installation labor (25% of hardware)', 1, 'lump sum', installCost, { optional: true }));
+    items.push(makeItem('sol_install', 'Labor', 'Installation labor (20% of hardware)', 1, 'lump sum', installCost, {
+      optional: true,
+      notes: `Requires ZERA ${getRequiredZeraTier(systemWatts)} licensed technician for this ${(systemWatts / 1000).toFixed(1)}kW system`,
+    }));
   }
 
+  // ── Contingency ───────────────────────────────────────────────────────
   if (answers.include_contingency) {
     const hardware = items.filter((i) => !i.owned && !i.optional).reduce((s, i) => s + i.totalCostUsd, 0);
     items.push(makeItem('sol_contingency', 'Contingency', 'Contingency (5%)', 1, 'lump sum', +(hardware * 0.05).toFixed(2), { optional: true }));
+  }
+
+  return items;
+}
+
+// ─── Maintenance BOQ ────────────────────────────────────────────────────────────
+
+export function maintenanceToBOQ(selectedServiceIds: string[]): BOQItem[] {
+  const items: BOQItem[] = [];
+
+  for (const svc of MAINTENANCE_SERVICES) {
+    if (selectedServiceIds.includes(svc.id)) {
+      items.push(makeItem(
+        `maint_${svc.id}`,
+        'Maintenance',
+        svc.label,
+        1,
+        'each',
+        svc.price,
+        { notes: svc.description },
+      ));
+    }
+  }
+
+  // Add transport if any physical on-site service selected
+  const onSiteServices = ['panel_cleaning', 'system_health_check', 'inverter_diagnostics', 'battery_replacement', 'wiring_inspection', 'surge_protection_install'];
+  if (selectedServiceIds.some((id) => onSiteServices.includes(id))) {
+    items.push(makeItem('maint_transport', 'Transport', 'Technician transport to site', 1, 'trip', SOLAR_PRICES.transport, { optional: true }));
   }
 
   return items;

--- a/src/lib/quick-projects/solar/calculations.ts
+++ b/src/lib/quick-projects/solar/calculations.ts
@@ -46,13 +46,16 @@ export const computeSolarSizing = (answers: SolarWizardAnswers): SolarSizingResu
     return sum + (watts * clampNumber(sel.qty, 0) * hours) / 1000;
   }, 0);
 
+  // Inverter: 1.25-1.3x safety margin on peak load (accounts for surge)
   const adjustedPeak = peakLoadWatts * 1.3;
   const inverterKva = roundToTier(adjustedPeak / 0.8 / 1000, INVERTER_TIERS);
 
+  // Battery: daily energy × 1.2 (for DoD headroom)
   const baseBattery = dailyEnergyKwh * 1.2;
   const batteryKwh = roundToTier(baseBattery, BATTERY_TIERS);
 
-  const solarArrayKw = Math.max(0.5, (dailyEnergyKwh / ZW_SUN_HOURS) * 1.2);
+  // Solar array: daily energy ÷ sun hours × 1.3 (system losses)
+  const solarArrayKw = Math.max(0.5, (dailyEnergyKwh / ZW_SUN_HOURS) * 1.3);
   const panelCount = Math.max(1, Math.ceil((solarArrayKw * 1000) / SOLAR_PANEL_WATT));
 
   const tier: SolarSizingResult['tier'] = inverterKva <= 3 ? 'small' : inverterKva <= 5 ? 'standard' : 'large';
@@ -69,6 +72,7 @@ export const computeSolarSizing = (answers: SolarWizardAnswers): SolarSizingResu
     high: benchmarkRange[1],
   };
 
+  // Warnings
   if (answers.simultaneousLoads.kettleMicrowave && inverterKva <= 3) {
     warnings.push('Kettle and microwave together may overload a 3kVA inverter.');
   }
@@ -78,7 +82,7 @@ export const computeSolarSizing = (answers: SolarWizardAnswers): SolarSizingResu
   }
 
   if (answers.simultaneousLoads.pumpWithHouse && inverterKva <= 5) {
-    warnings.push('Pumps have surge power; consider 8kVA if pumps run with household loads.');
+    warnings.push('Pumps have surge power (up to 3× running watts); consider 8kVA if pumps run with household loads.');
   }
 
   if (answers.roof.spaceM2 && panelCount * 2 > answers.roof.spaceM2) {
@@ -86,7 +90,16 @@ export const computeSolarSizing = (answers: SolarWizardAnswers): SolarSizingResu
   }
 
   if (answers.roof.shading === 'heavy') {
-    warnings.push('Heavy shading will reduce output; consider additional panels or trimming.');
+    warnings.push('Heavy shading will reduce output by up to 30%; consider additional panels or trimming trees.');
+  }
+
+  if (answers.roof.shading === 'partial') {
+    warnings.push('Partial shading can reduce output by 5-15%. Consider panel placement to minimize shadow impact.');
+  }
+
+  // ZESA integration warning
+  if (inverterKva >= 5) {
+    warnings.push('Important: Ensure your installer properly separates the solar neutral from the ZESA neutral to avoid prepaid meter "temper mode".');
   }
 
   return {

--- a/src/lib/quick-projects/solar/catalog.ts
+++ b/src/lib/quick-projects/solar/catalog.ts
@@ -1,13 +1,21 @@
+// ─── Solar Price Catalog — Zimbabwe Market Q1 2026 ────────────────────────────
+// Sources: Sona Solar, Taqon Electrico, Solarpro Zimbabwe, Techzim,
+//          ZERA regulations, HBOWA, strategic analysis.
+// Prices use mid-range of all sources for reliability.
+
 import { SolarApplianceInput } from './types';
 
 export const SOLAR_PANEL_WATT = 550;
 export const ZW_SUN_HOURS = 5.5;
+
+// ─── Appliances ───────────────────────────────────────────────────────────────
 
 export const SOLAR_APPLIANCES: SolarApplianceInput[] = [
   { id: 'lights', label: 'LED Lights', watts: 10, category: 'essential' },
   { id: 'tv', label: 'TV', watts: 120, category: 'essential' },
   { id: 'wifi', label: 'WiFi Router', watts: 20, category: 'essential' },
   { id: 'laptop', label: 'Laptop', watts: 60, category: 'essential' },
+  { id: 'phone_charger', label: 'Phone Charger', watts: 15, category: 'essential' },
   { id: 'fridge', label: 'Fridge', watts: 150, category: 'essential' },
   { id: 'freezer', label: 'Deep Freezer', watts: 200, category: 'essential' },
   { id: 'kettle', label: 'Kettle', watts: 2000, category: 'heavy' },
@@ -22,7 +30,10 @@ export const SOLAR_APPLIANCES: SolarApplianceInput[] = [
   { id: 'booster_pump', label: 'Booster Pump', watts: 900, category: 'pump' },
   { id: 'pool_pump', label: 'Pool Pump', watts: 1200, category: 'pump' },
   { id: 'office', label: 'Office Equipment', watts: 200, category: 'other' },
+  { id: 'security', label: 'Security System / CCTV', watts: 50, category: 'other' },
 ];
+
+// ─── Intent Labels ────────────────────────────────────────────────────────────
 
 export const SOLAR_INTENT_LABELS = {
   backup: 'Backup only (2–4 hrs)',
@@ -31,18 +42,382 @@ export const SOLAR_INTENT_LABELS = {
   replace: 'Replace or upgrade existing system',
   budget: 'Budget-fit system',
   quote_check: 'Quote check',
+  maintenance: 'Maintenance & servicing',
 } as const;
+
+// ─── Standard Tiers ───────────────────────────────────────────────────────────
 
 export const INVERTER_TIERS = [3, 5, 8, 10, 12];
-
 export const BATTERY_TIERS = [5, 10, 15, 20];
 
+// ─── Price Benchmarks (2025 mid-range) ────────────────────────────────────────
+// Updated from 2022 prices to 2025 Zimbabwe market mid-range.
+// Panel prices dropped ~60%, inverters ~40%, batteries ~30%.
+
 export const PRICE_BENCHMARKS = {
-  panelUsd: 110,
-  inverter5kvaUsd: 900,
-  battery5kwhUsd: 1100,
+  panelUsd: 70,              // mid-range 440-550W panel (was $110)
+  inverter5kvaUsd: 650,      // mid-range 5kVA hybrid (was $900)
+  battery5kwhUsd: 700,       // mid-range 5kWh LiFePO4 (was $1100)
   installPct: 0.25,
-  smallRange: [2500, 3000],
-  standardRange: [4500, 5000],
-  largeRange: [7000, 8000],
+  smallRange: [1400, 2000],  // 1-3kVA systems (was $2500-3000)
+  standardRange: [2500, 3500], // 5kVA systems (was $4500-5000)
+  largeRange: [4500, 7000],  // 8-12kVA systems (was $7000-8000)
 } as const;
+
+// ─── Inverter Brands & Pricing ────────────────────────────────────────────────
+// Per-unit prices for specific kVA sizes. Source: Sona Solar, Taqon, Techzim.
+
+export interface InverterOption {
+  brand: string;
+  label: string;
+  tier: 'budget' | 'mid' | 'premium';
+  prices: Record<number, number>; // kVA → USD
+  description: string;
+}
+
+export const INVERTER_BRANDS: InverterOption[] = [
+  {
+    brand: 'must',
+    label: 'Must',
+    tier: 'budget',
+    prices: { 3: 200, 5: 400, 8: 650, 10: 900, 12: 1100 },
+    description: 'Best value — reliable budget choice for homes.',
+  },
+  {
+    brand: 'codi',
+    label: 'Codi',
+    tier: 'budget',
+    prices: { 3: 180, 5: 380 },
+    description: 'Ultra-budget — high PV input voltage (450VDC) for flexible arrays.',
+  },
+  {
+    brand: 'kodak',
+    label: 'Kodak',
+    tier: 'mid',
+    prices: { 5: 700, 6: 650, 8: 950 },
+    description: 'Solid mid-range — good value for 5-8kVA systems.',
+  },
+  {
+    brand: 'srne',
+    label: 'SRNE',
+    tier: 'mid',
+    prices: { 3: 350, 5: 650, 8: 1000, 10: 1400 },
+    description: 'Robust quality — popular with installers for reliability.',
+  },
+  {
+    brand: 'growatt',
+    label: 'Growatt',
+    tier: 'mid',
+    prices: { 5: 850, 8: 1200, 10: 1600, 12: 2000 },
+    description: 'Scalable — silent operation, ideal for commercial use.',
+  },
+  {
+    brand: 'deye',
+    label: 'Deye',
+    tier: 'mid',
+    prices: { 5: 800, 8: 1200, 10: 1500, 12: 1900 },
+    description: 'Popular — stores daily totals on device, no internet needed.',
+  },
+  {
+    brand: 'sunsynk',
+    label: 'Sunsynk',
+    tier: 'premium',
+    prices: { 5: 900, 8: 1400, 10: 1700, 12: 2100 },
+    description: 'Premium — best when paired with Pylontech batteries.',
+  },
+  {
+    brand: 'solis',
+    label: 'Solis',
+    tier: 'premium',
+    prices: { 5: 950, 8: 1400, 10: 1800, 12: 2200 },
+    description: 'High efficiency — 4ms changeover, handles 2x PV array capacity.',
+  },
+  {
+    brand: 'victron',
+    label: 'Victron Energy',
+    tier: 'premium',
+    prices: { 3: 1200, 5: 1875, 8: 2800, 10: 3500 },
+    description: 'Best-in-class — unmatched longevity, modular, handles severe power fluctuations.',
+  },
+];
+
+// ─── Battery Brands & Pricing ─────────────────────────────────────────────────
+// Per-unit prices. Most units are ~5kWh (48V/51.2V × 100Ah).
+
+export interface BatteryOption {
+  brand: string;
+  label: string;
+  tier: 'budget' | 'mid' | 'premium';
+  pricePerKwh: number;        // USD per kWh
+  unitKwh: number;            // standard unit size
+  unitPrice: number;          // price per unit
+  description: string;
+}
+
+export const BATTERY_BRANDS: BatteryOption[] = [
+  {
+    brand: 'svolt',
+    label: 'Svolt',
+    tier: 'budget',
+    pricePerKwh: 117,
+    unitKwh: 2.56,
+    unitPrice: 300,
+    description: 'Budget — good entry-level option.',
+  },
+  {
+    brand: 'must',
+    label: 'Must',
+    tier: 'budget',
+    pricePerKwh: 120,
+    unitKwh: 5.12,
+    unitPrice: 600,
+    description: 'Budget — pairs well with Must inverters.',
+  },
+  {
+    brand: 'dyness',
+    label: 'Dyness',
+    tier: 'mid',
+    pricePerKwh: 160,
+    unitKwh: 5.12,
+    unitPrice: 790,
+    description: 'Sweet spot — premium performance at mid-tier price. 90-95% DoD.',
+  },
+  {
+    brand: 'pylontech',
+    label: 'Pylontech',
+    tier: 'mid',
+    pricePerKwh: 280,
+    unitKwh: 4.8,
+    unitPrice: 1350,
+    description: 'Industry standard — cross-inverter compatible, scalable across generations.',
+  },
+  {
+    brand: 'byd',
+    label: 'BYD',
+    tier: 'premium',
+    pricePerKwh: 300,
+    unitKwh: 5.12,
+    unitPrice: 1536,
+    description: 'Global leader — blade technology, 6000+ cycles, EV-grade safety.',
+  },
+  {
+    brand: 'freedomwon',
+    label: 'FreedomWon',
+    tier: 'premium',
+    pricePerKwh: 280,
+    unitKwh: 5.0,
+    unitPrice: 1400,
+    description: 'Made for Africa — 6000+ cycles, engineered for harsh climates.',
+  },
+  {
+    brand: 'cento',
+    label: 'Cento',
+    tier: 'mid',
+    pricePerKwh: 200,
+    unitKwh: 5.12,
+    unitPrice: 1024,
+    description: '5-layer safety, AI monitoring, IP65 rated (indoor/outdoor).',
+  },
+  {
+    brand: 'revov',
+    label: 'Revov',
+    tier: 'mid',
+    pricePerKwh: 180,
+    unitKwh: 5.12,
+    unitPrice: 920,
+    description: 'Eco-friendly — repurposed second-life EV batteries.',
+  },
+];
+
+// ─── Panel Brands & Pricing ───────────────────────────────────────────────────
+
+export interface PanelOption {
+  brand: string;
+  label: string;
+  watt: number;
+  pricePerPanel: number;
+  pricePerWatt: number;
+}
+
+export const PANEL_BRANDS: PanelOption[] = [
+  { brand: 'longi', label: 'Longi', watt: 430, pricePerPanel: 50, pricePerWatt: 0.116 },
+  { brand: 'ja_solar', label: 'JA Solar', watt: 440, pricePerPanel: 56, pricePerWatt: 0.127 },
+  { brand: 'aiko', label: 'Aiko', watt: 595, pricePerPanel: 72, pricePerWatt: 0.121 },
+  { brand: 'jinko', label: 'Jinko', watt: 585, pricePerPanel: 80, pricePerWatt: 0.137 },
+  { brand: 'canadian', label: 'Canadian Solar', watt: 550, pricePerPanel: 90, pricePerWatt: 0.164 },
+  { brand: 'trina', label: 'Trina', watt: 550, pricePerPanel: 100, pricePerWatt: 0.182 },
+];
+
+// ─── Pre-Built Packages ───────────────────────────────────────────────────────
+// Sourced from Solarpro, Sona Solar. These are real market packages.
+
+export interface SolarPackage {
+  id: string;
+  name: string;
+  provider: string;
+  kva: number;
+  batteryKwh: number;
+  panelCount: number;
+  panelWatt: number;
+  price: number;
+  description: string;
+  appliances: string;        // what it can run
+}
+
+export const SOLAR_PACKAGES: SolarPackage[] = [
+  {
+    id: 'pkg_1kva_economy',
+    name: '1kVA Economy Lite',
+    provider: 'Sona Solar',
+    kva: 1, batteryKwh: 2.56, panelCount: 2, panelWatt: 440,
+    price: 900,
+    description: 'Basic backup for essential devices.',
+    appliances: 'Lights, WiFi, TV, phone charging',
+  },
+  {
+    id: 'pkg_3kva_basic',
+    name: '3kVA Basic',
+    provider: 'Solarpro',
+    kva: 3, batteryKwh: 2.56, panelCount: 2, panelWatt: 440,
+    price: 1850,
+    description: 'Entry-level with solar charging.',
+    appliances: 'Lights, TV, fridge, laptop',
+  },
+  {
+    id: 'pkg_3kva_eco',
+    name: '3.2kVA Eco Luxury',
+    provider: 'Sona Solar',
+    kva: 3, batteryKwh: 5.12, panelCount: 4, panelWatt: 440,
+    price: 1500,
+    description: 'Good backup for a small household.',
+    appliances: 'Lights, TV, fridge, laptop',
+  },
+  {
+    id: 'pkg_3kva_premium',
+    name: '3kVA Premium',
+    provider: 'Solarpro',
+    kva: 3, batteryKwh: 5.12, panelCount: 4, panelWatt: 440,
+    price: 2850,
+    description: 'Extended backup with double battery storage.',
+    appliances: 'Lights, TVs, fridge, freezer, 0.5HP pump',
+  },
+  {
+    id: 'pkg_5kva_standard',
+    name: '5kVA Standard',
+    provider: 'Solarpro',
+    kva: 5, batteryKwh: 10.24, panelCount: 8, panelWatt: 440,
+    price: 3360,
+    description: 'Most popular — covers a medium home with pump.',
+    appliances: 'Lights, TV, fridge, booster/borehole pump',
+  },
+  {
+    id: 'pkg_5kva_luxury',
+    name: '5kVA Luxury Beta',
+    provider: 'Sona Solar',
+    kva: 5, batteryKwh: 9.6, panelCount: 8, panelWatt: 550,
+    price: 2500,
+    description: 'Full household power with lithium batteries.',
+    appliances: 'Lights, TV, fridge, borehole pump, entertainment',
+  },
+  {
+    id: 'pkg_6kva_offgrid',
+    name: '6kVA Off-Grid Home',
+    provider: 'Solarpro',
+    kva: 6, batteryKwh: 10.24, panelCount: 10, panelWatt: 440,
+    price: 4180,
+    description: 'Full off-grid for a large household.',
+    appliances: '2 TVs, 2 fridges, microwave, lights',
+  },
+  {
+    id: 'pkg_8kva_ultra',
+    name: '8kVA Ultra Power',
+    provider: 'Solarpro',
+    kva: 8, batteryKwh: 20.48, panelCount: 16, panelWatt: 420,
+    price: 6000,
+    description: 'Heavy-duty — powers everything including heavy loads.',
+    appliances: 'Full household + heavy appliances',
+  },
+  {
+    id: 'pkg_10kva_pro',
+    name: '10kVA Pro Power',
+    provider: 'Solarpro',
+    kva: 10, batteryKwh: 20.48, panelCount: 22, panelWatt: 420,
+    price: 7700,
+    description: 'Commercial-grade for large properties.',
+    appliances: 'Full household + multiple heavy loads',
+  },
+  {
+    id: 'pkg_12kva_commercial',
+    name: '12kVA Commercial',
+    provider: 'Solarpro',
+    kva: 12, batteryKwh: 20.48, panelCount: 22, panelWatt: 420,
+    price: 6070,
+    description: 'Entry-level commercial system.',
+    appliances: 'Small business, lodge, school',
+  },
+];
+
+// ─── Maintenance Services ─────────────────────────────────────────────────────
+
+export interface MaintenanceService {
+  id: string;
+  label: string;
+  description: string;
+  price: number;
+}
+
+export const MAINTENANCE_SERVICES: MaintenanceService[] = [
+  {
+    id: 'panel_cleaning',
+    label: 'Solar panel cleaning',
+    description: 'Professional cleaning to remove dust, pollen, and bird droppings. Can restore 5-30% output.',
+    price: 50,
+  },
+  {
+    id: 'system_health_check',
+    label: 'System health check',
+    description: 'Full inspection — wiring, connections, grounding, ventilation, and voltage verification.',
+    price: 80,
+  },
+  {
+    id: 'inverter_diagnostics',
+    label: 'Inverter diagnostics & reprogramming',
+    description: 'Fix ZESA tripping, battery charging issues, temper mode, or voltage range problems.',
+    price: 100,
+  },
+  {
+    id: 'battery_replacement',
+    label: 'Battery replacement',
+    description: 'Remove old battery and install new one. Battery cost separate.',
+    price: 75,
+  },
+  {
+    id: 'wiring_inspection',
+    label: 'Wiring inspection & repair',
+    description: 'Check for loose connections, water ingress, arc faults, and earthing issues.',
+    price: 120,
+  },
+  {
+    id: 'surge_protection_install',
+    label: 'Surge protection upgrade',
+    description: 'Install or replace DC/AC surge protection devices and automatic voltage switcher.',
+    price: 150,
+  },
+];
+
+// ─── ZERA License Tiers ───────────────────────────────────────────────────────
+
+export const ZERA_TIERS = {
+  ST1: { maxWatt: 400, label: 'Up to 400W (basic lighting systems)' },
+  ST2: { maxWatt: 2000, label: 'Up to 2kW (small home systems)' },
+  ST3: { maxWatt: 50000, label: 'Up to 50kW grid-tied / 10kW hybrid' },
+  ST4: { maxWatt: Infinity, label: 'Unlimited capacity' },
+} as const;
+
+/** Returns the minimum ZERA technician tier needed for a given system size in watts. */
+export function getRequiredZeraTier(systemWatts: number): string {
+  if (systemWatts <= 400) return 'ST1';
+  if (systemWatts <= 2000) return 'ST2';
+  if (systemWatts <= 50000) return 'ST3';
+  return 'ST4';
+}

--- a/src/lib/quick-projects/solar/types.ts
+++ b/src/lib/quick-projects/solar/types.ts
@@ -4,7 +4,8 @@ export type SolarIntent =
   | 'off_grid'
   | 'replace'
   | 'budget'
-  | 'quote_check';
+  | 'quote_check'
+  | 'maintenance';
 
 export type PropertyType = 'apartment' | 'house' | 'farm' | 'business';
 


### PR DESCRIPTION
## Summary
- **Solar Budget Explorer**: One-page interactive budget calculator with 5 toggle-able component cards (panels, inverter, battery, protection, installation), brand pickers, package matching, and smart budget allocation algorithm
- **Borehole Budget Explorer**: One-page budget calculator with 7 toggle-able cards (drilling, casing, pump & power, water storage, professional services, permits, mobilization), depth slider, location picker, pump type/casing grade selectors
- Both explorers integrate into their respective wizard flows via a new "Budget Explorer" estimate mode option on step 1
- Expanded borehole flow with full estimate_mode selection (Quick/Detailed/Budget), 22+ conditional steps, and comprehensive Zimbabwe-specific pricing
- Extended solar catalog with inverter/battery/panel brands, packages, and maintenance services

## Test plan
- [ ] Navigate to `/quick-projects/borehole` → select "Budget Explorer" → verify budget explorer renders with toggle cards
- [ ] Enter a budget amount, toggle cards on/off, change pump type/casing grade → verify live cost recalculation
- [ ] Navigate to `/quick-projects/solar` → select "Fit My Budget" → verify solar budget explorer renders
- [ ] Enter budget, toggle components, change brands → verify budget bar and recommendations update
- [ ] Generate BOQ from both explorers → verify QuickBOQTable renders with correct line items
- [ ] Test save flow from both explorers

🤖 Generated with [Claude Code](https://claude.com/claude-code)